### PR TITLE
Greenmask v0.1.2 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CMD_FILES = $(wildcard *.go)
 TEST_FILES = $(wildcard *.go)
 COVERAGE_FILE := coverage.out
 VERSION ?= $(shell git tag --points-at HEAD)
-LDFLAGS ?= -X main.version=$(VERSION)
+LDFLAGS ?= -X github.com/greenmaskio/greenmask/cmd/greenmask/cmd.Version=$(VERSION)
 
 .PHONY: build
 

--- a/cmd/greenmask/main.go
+++ b/cmd/greenmask/main.go
@@ -20,10 +20,7 @@ import (
 	"github.com/greenmaskio/greenmask/cmd/greenmask/cmd"
 )
 
-var version string
-
 func main() {
-	cmd.Version = version
 	if err := cmd.Execute(); err != nil {
 		log.Fatal().Err(err).Msg("")
 	}

--- a/internal/db/postgres/pgcopy/row.go
+++ b/internal/db/postgres/pgcopy/row.go
@@ -73,7 +73,7 @@ func (r *Row) Decode(raw []byte) error {
 
 	// Building column position slice
 	idx := 0
-	for colStartPos < len(raw) {
+	for colStartPos <= len(raw) {
 
 		colEndPos = slices.Index(raw[colStartPos:], DefaultCopyDelimiter)
 		if colEndPos == -1 {

--- a/internal/db/postgres/pgdump/pgdump.go
+++ b/internal/db/postgres/pgdump/pgdump.go
@@ -104,10 +104,11 @@ type Options struct {
 }
 
 func (o *Options) GetPgDSN() (string, error) {
-	//return "host=localhost port=5432 user=postgres dbname=postgres", nil
-	if strings.Contains(o.DbName, "=") {
+	// URI or Standard format
+	if strings.HasPrefix(o.DbName, "postgresql://") || strings.Contains(o.DbName, "=") {
 		return o.DbName, nil
 	}
+
 	return fmt.Sprintf("host=%s port=%d user=%s dbname=%s", o.Host, o.Port, o.UserName, o.DbName), nil
 }
 


### PR DESCRIPTION
This PR introduces a bug fixes:

* Fixed bug when raw COPY lines were parsed incorrectly #2 
* Fixed `--version` parameter behaviour
* Fixed `--dbname` parameter - now it correctly works with PostgreSQL connection string in URI format `postgresql:///`