### PR TITLE
New Hash transformer implementation and validation warning fixes

### DIFF
--- a/internal/db/postgres/transformers/cmd.go
+++ b/internal/db/postgres/transformers/cmd.go
@@ -455,7 +455,7 @@ func cmdValidateSkipBehaviour(p *toolkit.Parameter, v toolkit.ParamsValue) (tool
 	if value != skipOnAnyName && value != skipOnAllName {
 		return toolkit.ValidationWarnings{
 			toolkit.NewValidationWarning().
-				AddMeta("ParameterName", p.Name).
+				SetSeverity(toolkit.ErrorValidationSeverity).
 				AddMeta("ParameterValue", value).
 				SetMsg(`unsupported skip_on type: must be one of "all" or "any"`),
 		}, nil

--- a/internal/db/postgres/transformers/hash_test.go
+++ b/internal/db/postgres/transformers/hash_test.go
@@ -23,46 +23,212 @@ import (
 	"github.com/greenmaskio/greenmask/pkg/toolkit"
 )
 
-func TestHashTransformer_Transform(t *testing.T) {
-	var attrName = "data"
-	var originalValue = "old_value"
-	var expectedValue = toolkit.NewValue("jzTVGK2UHz3ERhrYiZDoDzcKeMxSsgxHHgWlL9OrkZ4=", false)
-	driver, record := getDriverAndRecord(attrName, originalValue)
+func TestHashTransformer_Transform_all_functions(t *testing.T) {
+	columnValue := toolkit.ParamsValue("data")
 
+	tests := []struct {
+		name     string
+		params   map[string]toolkit.ParamsValue
+		original string
+		result   string
+	}{
+		{
+			name: "md5",
+			params: map[string]toolkit.ParamsValue{
+				"column":   columnValue,
+				"function": []byte("md5"),
+			},
+			original: "123",
+			result:   "202cb962ac59075b964b07152d234b70",
+		},
+		{
+			name: "sha1",
+			params: map[string]toolkit.ParamsValue{
+				"column":   columnValue,
+				"function": []byte("sha1"),
+			},
+			original: "123",
+			result:   "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
+		},
+		{
+			name: "sha256",
+			params: map[string]toolkit.ParamsValue{
+				"column":   columnValue,
+				"function": []byte("sha256"),
+			},
+			original: "123",
+			result:   "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+		},
+		{
+			name: "sha512",
+			params: map[string]toolkit.ParamsValue{
+				"column":   columnValue,
+				"function": []byte("sha512"),
+			},
+			original: "123",
+			result:   "3c9909afec25354d551dae21590bb26e38d53f2173b8d3dc3eee4c047e7ab1c1eb8b85103e3be7ba613b31bb5c9c36214dc9f14a42fd7a2fdb84856bca5c44c2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver, record := getDriverAndRecord(string(tt.params["column"]), tt.original)
+			transformer, warnings, err := HashTransformerDefinition.Instance(
+				context.Background(),
+				driver, tt.params,
+				nil,
+			)
+			require.NoError(t, err)
+			require.Empty(t, warnings)
+			r, err := transformer.Transform(
+				context.Background(),
+				record,
+			)
+			require.NoError(t, err)
+
+			res, err := r.GetRawColumnValueByName(string(tt.params["column"]))
+			require.NoError(t, err)
+
+			require.False(t, res.IsNull)
+			require.Equal(t, tt.result, string(res.Data))
+
+		})
+	}
+}
+
+func Test_validateHashFunctionsParameter(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		value []byte
+	}{
+		{
+			name:  "md5",
+			value: []byte("md5"),
+		},
+		{
+			name:  "sha1",
+			value: []byte("md5"),
+		},
+		{
+			name:  "sha256",
+			value: []byte("md5"),
+		},
+		{
+			name:  "sha512",
+			value: []byte("md5"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warns, err := validateHashFunctionsParameter(nil, tt.value)
+			require.NoError(t, err)
+			require.Empty(t, warns)
+		})
+	}
+
+	t.Run("wrong value", func(t *testing.T) {
+		warns, err := validateHashFunctionsParameter(nil, []byte("md8"))
+		require.NoError(t, err)
+		require.Len(t, warns, 1)
+		warn := warns[0]
+		require.Equal(t, toolkit.ErrorValidationSeverity, warn.Severity)
+		require.Equal(t, "unknown hash function name", warn.Msg)
+	})
+
+}
+
+func TestHashTransformer_Transform_length_truncation(t *testing.T) {
+
+	params := map[string]toolkit.ParamsValue{
+		"column":     toolkit.ParamsValue("data"),
+		"max_length": toolkit.ParamsValue("4"),
+		"function":   toolkit.ParamsValue("sha1"),
+	}
+	original := "123"
+	expected := "40bd"
+	// Check that internal buffers wipes correctly without data lost
+	driver, record := getDriverAndRecord(string(params["column"]), original)
 	transformer, warnings, err := HashTransformerDefinition.Instance(
 		context.Background(),
-		driver, map[string]toolkit.ParamsValue{
-			"column": toolkit.ParamsValue(attrName),
-			"salt":   toolkit.ParamsValue("MTIzNDU2Nw=="),
-		},
+		driver, params,
 		nil,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
-
 	r, err := transformer.Transform(
 		context.Background(),
 		record,
 	)
 	require.NoError(t, err)
-	res, err := r.GetColumnValueByName(attrName)
+
+	res, err := r.GetRawColumnValueByName(string(params["column"]))
 	require.NoError(t, err)
 
-	require.Equal(t, expectedValue.IsNull, res.IsNull)
-	require.Equal(t, expectedValue.Value, res.Value)
+	require.False(t, res.IsNull)
+	require.Equal(t, expected, string(res.Data))
+}
 
-	originalValue = "123asdasdasdaasdlmaklsdmklamsdlkmalksdmlkamsdlkmalkdmlkasds"
-	expectedValue = toolkit.NewValue("kZsJbWbVoBGMqniHTCzU6fJrxQdlfeqhYIUxOo3JniA=", false)
-	_, record = getDriverAndRecord(attrName, originalValue)
-	r, err = transformer.Transform(
+func TestHashTransformer_Transform_multiple_iterations(t *testing.T) {
+	columnValue := toolkit.ParamsValue("data")
+
+	params := map[string]toolkit.ParamsValue{
+		"column":   toolkit.ParamsValue("data"),
+		"function": toolkit.ParamsValue("sha1"),
+	}
+	original := "123"
+	// Check that internal buffers wipes correctly without data lost
+	driver, record := getDriverAndRecord(string(params["column"]), original)
+	transformer, warnings, err := HashTransformerDefinition.Instance(
 		context.Background(),
-		record,
+		driver, params,
+		nil,
 	)
 	require.NoError(t, err)
-	res, err = r.GetColumnValueByName(attrName)
-	require.NoError(t, err)
+	require.Empty(t, warnings)
 
-	require.Equal(t, expectedValue.IsNull, res.IsNull)
-	require.Equal(t, expectedValue.Value, res.Value)
+	tests := []struct {
+		name     string
+		original string
+		expected string
+	}{
+		{
+			name:     "run1",
+			original: "123",
+			expected: "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
+		},
+		{
+			name:     "run2",
+			original: "456",
+			expected: "51eac6b471a284d3341d8c0c63d0f1a286262a18",
+		},
+		{
+			name:     "run3",
+			original: "789",
+			expected: "fc1200c7a7aa52109d762a9f005b149abef01479",
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer record.Row.Encode()
+
+			err = record.Row.Decode([]byte(tt.original))
+			require.NoError(t, err)
+
+			_, err = transformer.Transform(
+				context.Background(),
+				record,
+			)
+			require.NoError(t, err)
+
+			res, err := record.GetRawColumnValueByName(string(columnValue))
+			require.NoError(t, err)
+
+			require.False(t, res.IsNull)
+			require.Equal(t, tt.expected, string(res.Data))
+
+		})
+	}
 }

--- a/pkg/toolkit/parameter.go
+++ b/pkg/toolkit/parameter.go
@@ -351,15 +351,15 @@ func (p *Parameter) Init(driver *Driver, types []*Type, params []*Parameter, raw
 	}
 
 	if p.RawValueValidator != nil {
-		w, err := p.RawValueValidator(p, p.rawValue)
+		rawValueValidatorWarns, err := p.RawValueValidator(p, p.rawValue)
 		if err != nil {
 			return nil, fmt.Errorf("error performing parameter raw value validation: %w", err)
 		}
-		for _, w := range warnings {
+		for _, w := range rawValueValidatorWarns {
 			w.AddMeta("ParameterName", p.Name)
 		}
-		warnings = append(warnings, w...)
-		if w.IsFatal() {
+		warnings = append(warnings, rawValueValidatorWarns...)
+		if rawValueValidatorWarns.IsFatal() {
 			return warnings, nil
 		}
 	}


### PR DESCRIPTION
### New Hash transformer implementation and validation warning fixes

* New `Hash` transformer uses `sha1` hash by default.
* Added parameter `function` that can provide a choice of possible hash algorithms `md5, sha1, sha256, sha512`.
* Added `max_length` parameter allowing to truncate hash tail higher than provided length. The default value is `0` - meaning "do not truncate"
* Fixed metadata enrichment for validation warnings caused by `RawValueValidator`

**Example:**

```yaml
- schema: "humanresources"
  name: "employee"
  transformers:
    - name: "Hash"
      params:
        column: "loginid"
        function: "sha1"
        max_length: 10
```

Additional changes:
* Added Error severity for Cmd parameter validator

Closes #8 