### PR TITLE
restore and show-dump command fixes

### DIFF
--- a/internal/db/postgres/cmd/show_dump.go
+++ b/internal/db/postgres/cmd/show_dump.go
@@ -38,7 +38,7 @@ const (
 )
 
 var templateString = `;
-; Archive created at {{ .Header.CreationDate.TableFormat "2006-01-02 15:04:05 UTC" }}
+; Archive created at {{ .Header.CreationDate.Format "2006-01-02 15:04:05 UTC" }}
 ;     dbname: {{ .Header.DbName }}
 ;     TOC Entries: {{ .Header.TocEntriesCount }}
 ;     Compression: {{ .Header.Compression }}

--- a/internal/db/postgres/toc/entry.go
+++ b/internal/db/postgres/toc/entry.go
@@ -61,3 +61,42 @@ type Entry struct {
 	//OriginalSize   int64
 	//CompressedSize int64
 }
+
+func (e *Entry) Copy() *Entry {
+	res := NewObj(*e)
+	if e.Tag != nil {
+		res.Tag = NewObj(*e.Tag)
+	}
+	if e.Namespace != nil {
+		res.Namespace = NewObj(*e.Namespace)
+	}
+	if e.Tablespace != nil {
+		res.Tablespace = NewObj(*e.Tablespace)
+	}
+	if e.Tableam != nil {
+		res.Tableam = NewObj(*e.Tableam)
+	}
+	if e.Owner != nil {
+		res.Owner = NewObj(*e.Owner)
+	}
+	if e.Desc != nil {
+		res.Desc = NewObj(*e.Desc)
+	}
+	if e.Defn != nil {
+		res.Defn = NewObj(*e.Defn)
+	}
+	if e.DropStmt != nil {
+		res.DropStmt = NewObj(*e.DropStmt)
+	}
+	if e.CopyStmt != nil {
+		res.CopyStmt = NewObj(*e.CopyStmt)
+	}
+	if e.FileName != nil {
+		res.FileName = NewObj(*e.FileName)
+	}
+	return res
+}
+
+func NewObj[T string | Toc | Header | Entry](v T) *T {
+	return &v
+}

--- a/internal/db/postgres/toc/header.go
+++ b/internal/db/postgres/toc/header.go
@@ -54,3 +54,17 @@ type Header struct {
 	TocCount             int32
 	MaxDumpId            int32
 }
+
+func (h *Header) Copy() *Header {
+	res := NewObj(*h)
+	if h.ArchDbName != nil {
+		res.ArchDbName = NewObj(*h.ArchDbName)
+	}
+	if h.ArchiveRemoteVersion != nil {
+		res.ArchiveRemoteVersion = NewObj(*h.ArchiveRemoteVersion)
+	}
+	if h.ArchiveDumpVersion != nil {
+		res.ArchiveDumpVersion = NewObj(*h.ArchiveDumpVersion)
+	}
+	return res
+}

--- a/internal/db/postgres/toc/toc.go
+++ b/internal/db/postgres/toc/toc.go
@@ -18,3 +18,17 @@ type Toc struct {
 	Header  *Header
 	Entries []*Entry
 }
+
+func (t *Toc) Copy() *Toc {
+
+	entries := make([]*Entry, len(t.Entries))
+
+	for i, entry := range t.Entries {
+		entries[i] = entry.Copy()
+	}
+
+	return &Toc{
+		Header:  t.Header.Copy(),
+		Entries: entries,
+	}
+}

--- a/internal/utils/cmd_runner/cmd_runner.go
+++ b/internal/utils/cmd_runner/cmd_runner.go
@@ -88,7 +88,7 @@ func Run(ctx context.Context, logger *zerolog.Logger, name string, args ...strin
 		defer outWriter.Close()
 		defer errWriter.Close()
 		if err := cmd.Wait(); err != nil {
-			return fmt.Errorf("external command runtime error: %w", err)
+			return err
 		}
 		return nil
 	})


### PR DESCRIPTION
* Implemented `--exit-on-error` parameter for pg_restore run. But it does not play for "data" section restoration now. If any error is caused in "data" section - greenmask exits with the error
* Fixed dependant objects dropping when running with `--clean` parameter
* Fixed `show-dump` command in text mode