### PR TITLE
Fixed s3 region env variable providing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ two storage options are supported: `directory` and `s3`.
     * `prefix` — a prefix for objects in the bucket, specified in path format
     * `region` — the S3 service region
     * `storage_class` — the storage class for performing object requests
-    * `no_verify_ssl` — disable SSL for interactions (default is `false`)
+    * `no_verify_ssl` — disable SSL certificate verification
     * `access_key_id` — access key for authentication
     * `secret_access_key` — secret access key for authentication
     * `session_token` — session token for authentication

--- a/internal/storages/s3/config.go
+++ b/internal/storages/s3/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	UseListObjectsV1 bool   `mapstructure:"use_list_objects_v1,omitempty"`
 	ForcePathStyle   bool   `mapstructure:"force_path_style,omitempty"`
 	UseAccelerate    bool   `mapstructure:"use_accelerate,omitempty"`
+	NoVerifySsl      bool   `mapstructure:"no_verify_ssl,omitempty"`
 }
 
 func NewConfig() *Config {

--- a/internal/storages/s3/s3.go
+++ b/internal/storages/s3/s3.go
@@ -16,9 +16,11 @@ package s3
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -121,6 +123,13 @@ func NewStorage(ctx context.Context, cfg *Config, logLevel string) (*Storage, er
 	}
 	awsCfg.WithLogger(LogWrapper{logger: &log.Logger})
 	awsCfg.WithLogLevel(lv)
+
+	if cfg.NoVerifySsl {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		awsCfg.WithHTTPClient(&http.Client{Transport: tr})
+	}
 
 	if cfg.Endpoint != "" {
 		awsCfg.WithEndpoint(cfg.Endpoint)

--- a/internal/storages/s3/s3.go
+++ b/internal/storages/s3/s3.go
@@ -150,6 +150,11 @@ func NewStorage(ctx context.Context, cfg *Config, logLevel string) (*Storage, er
 		},
 	)
 
+	log.Debug().
+		Str("region", *service.Config.Region).
+		Str("bucket", cfg.Bucket).
+		Msg("s3 storage bucket")
+
 	return &Storage{
 		prefix:   fixPrefix(path.Join(cfg.Bucket, cfg.Prefix)),
 		session:  ses,

--- a/internal/storages/s3/s3.go
+++ b/internal/storages/s3/s3.go
@@ -125,7 +125,10 @@ func NewStorage(ctx context.Context, cfg *Config, logLevel string) (*Storage, er
 	if cfg.Endpoint != "" {
 		awsCfg.WithEndpoint(cfg.Endpoint)
 	}
-	awsCfg.WithRegion(cfg.Region)
+
+	if cfg.Region != "" {
+		awsCfg.WithRegion(cfg.Region)
+	}
 
 	if cfg.CertFile != "" {
 		file, err := os.Open(cfg.CertFile)


### PR DESCRIPTION
Fixed region value provided via environment variable `AWS_REGION` for s3 storage

Found when investigated #36