### PR TITLE
Add environment variable section to the configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -295,3 +295,24 @@ scripts:
 2. **List of data stage scripts**. This section contains scripts that are executed before or after the restoration of the data section. The scripts include shell commands with parameters and SQL query files.
 3. **List of post-data stage scripts**. This section contains scripts that are executed before or after the restoration of the post-data section. The scripts include SQL queries and query files.
 4. **Command in the first argument and the parameters in the rest of the list**. When specifying a command to be executed in the scripts section, you provide the command name as the first item in a list, followed by any parameters or arguments for that command. The command and its parameters are provided as a list within the script configuration.
+
+## Environment variable configuration
+
+It's also possible to configure Greenmask through environment variables.
+
+### Postgres connection variables
+
+Variables used in the `dump` and `restore` commands to configure connection with Postgres database
+
+* `PGHOST` - host used to connect to the postgres database
+* `PGPORT` - port where postgres is exposed
+* `PGDATABASE` - name of the database to dump/restore
+* `PGUSER` - username used to connect to the postgres database
+* `PGPASSWORD` - password used to authenticate to the postgres database
+
+### Log configuration variables
+
+Configures Greenmask logging, possible values are described above in the `log` section of this docummentation
+
+* `LOG_FORMAT` - configures log format
+* `LOG_LEVEL` - configures log level


### PR DESCRIPTION
While I was exploring the repository code, I noticed that there are some environment variables configuration available that are undocumented.

Using environment variables for configuration is extremely useful, specially when running Greenmask as a Job inside a cluster.

I also would like to suggest the addition of some other environment variables that could improve ease configuration:

- Storage
  - `TYPE` - chose storage type, valid values are `directory` or `s3`
  - `BUCKET_NAME`
  - `BUCKET_REGION` - recently the possibility to set the region through the `AWS_REGION` environment variable was added, but adding this additional variable would align for a more cohesive env var naming
  - `PATH` - for `directory` storage, but this could also be used as `prefix` when using `s3` storage

Other variables for storage would also be beneficial, but I believe that these would cover the majority of the users