### PR TITLE
Add environment variable configuration for storage

### DIFF
--- a/internal/storages/builder/builder.go
+++ b/internal/storages/builder/builder.go
@@ -17,6 +17,7 @@ package builder
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/greenmaskio/greenmask/internal/domains"
 	"github.com/greenmaskio/greenmask/internal/storages"
@@ -27,9 +28,10 @@ import (
 func GetStorage(ctx context.Context, stCfg *domains.StorageConfig, logCgf *domains.LogConfig) (
 	storages.Storager, error,
 ) {
-	if stCfg.Directory != nil {
+	envCfg := os.Getenv("STORAGE_TYPE")
+	if stCfg.Directory != nil || envCfg == "directory" {
 		return directory.NewStorage(stCfg.Directory)
-	} else if stCfg.S3 != nil {
+	} else if (stCfg.S3 != nil || envCfg == "s3" {
 		return s3.NewStorage(ctx, stCfg.S3, logCgf.Level)
 	}
 	return nil, errors.New("no one storage was provided")

--- a/internal/storages/builder/builder.go
+++ b/internal/storages/builder/builder.go
@@ -31,7 +31,7 @@ func GetStorage(ctx context.Context, stCfg *domains.StorageConfig, logCgf *domai
 	envCfg := os.Getenv("STORAGE_TYPE")
 	if stCfg.Directory != nil || envCfg == "directory" {
 		return directory.NewStorage(stCfg.Directory)
-	} else if (stCfg.S3 != nil || envCfg == "s3" {
+	} else if stCfg.S3 != nil || envCfg == "s3" {
 		return s3.NewStorage(ctx, stCfg.S3, logCgf.Level)
 	}
 	return nil, errors.New("no one storage was provided")

--- a/internal/storages/directory/config.go
+++ b/internal/storages/directory/config.go
@@ -14,6 +14,24 @@
 
 package directory
 
+import (
+	"errors"
+	"os"
+)
+
 type Config struct {
 	Path string `mapstructure:"path"`
+}
+
+func NewConfig() *Config {
+	return &Config{
+		Path:   os.Getenv("STORAGE_DIRECTORY_PATH"),
+	}
+}
+
+func (c *Config) Validate() error {
+	if c.Path == "" {
+		return errors.New("path cannot be empty when using directory storage")
+	}
+	return nil
 }

--- a/internal/storages/s3/config.go
+++ b/internal/storages/s3/config.go
@@ -16,6 +16,7 @@ package s3
 
 import (
 	"errors"
+	"os"
 )
 
 const (
@@ -50,6 +51,9 @@ func NewConfig() *Config {
 		ForcePathStyle: true,
 		MaxRetries:     defaultMaxRetries,
 		MaxPartSize:    defaultMaxPartSize,
+		Bucket:   		os.Getenv("BUCKET_NAME"),
+		Region: 		os.Getenv("BUCKET_REGION"),
+		Prefix:			os.Getenv("BUCKET_PREFIX"),
 	}
 }
 

--- a/internal/storages/s3/config.go
+++ b/internal/storages/s3/config.go
@@ -51,9 +51,9 @@ func NewConfig() *Config {
 		ForcePathStyle: true,
 		MaxRetries:     defaultMaxRetries,
 		MaxPartSize:    defaultMaxPartSize,
-		Bucket:   		os.Getenv("BUCKET_NAME"),
-		Region: 		os.Getenv("BUCKET_REGION"),
-		Prefix:			os.Getenv("BUCKET_PREFIX"),
+		Bucket:   		os.Getenv("STORAGE_S3_BUCKET_NAME"),
+		Region: 		os.Getenv("STORAGE_S3_BUCKET_REGION"),
+		Prefix:			os.Getenv("STORAGE_S3_BUCKET_PREFIX"),
 	}
 }
 


### PR DESCRIPTION
@wwoytenko I've added some of the variables proposed in #41. I already tested locally that these changes work and if you agree to add this PR to the project, I can also add the related docs to the other PR.

I'm still getting used to Go and the project, but I couldn't figure out where I could add the toggle to switch between `directory` and `s3` storage as an environment variable (the proposed `STORAGE_TYPE` env var)