### PR TITLE
Table size and transformation scoring

### DIFF
--- a/internal/db/postgres/context/context.go
+++ b/internal/db/postgres/context/context.go
@@ -17,6 +17,7 @@ package context
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -27,6 +28,8 @@ import (
 	"github.com/greenmaskio/greenmask/internal/domains"
 	"github.com/greenmaskio/greenmask/pkg/toolkit"
 )
+
+const defaultTransformerCostMultiplier = 0.03
 
 // RuntimeContext - describes current runtime behaviour according to the config and schema objects
 type RuntimeContext struct {
@@ -73,6 +76,8 @@ func NewRuntimeContext(
 		return nil, fmt.Errorf("cannot build dump object list: %w", err)
 	}
 
+	scoreTablesEntriesAndSort(dataSectionObjects, cfg)
+
 	schema, err := getDatabaseSchema(ctx, tx, opt)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get database schema: %w", err)
@@ -90,4 +95,43 @@ func NewRuntimeContext(
 
 func (rc *RuntimeContext) IsFatal() bool {
 	return rc.Warnings.IsFatal()
+}
+
+func scoreTablesEntriesAndSort(dataSectionObjects []entries.Entry, cfg []*domains.Table) {
+	for _, entry := range dataSectionObjects {
+		t, ok := entry.(*entries.Table)
+		if ok {
+			var transformersCount float64
+			idx := slices.IndexFunc(cfg, func(table *domains.Table) bool {
+				return table.Name == t.Name && table.Schema == t.Schema
+			})
+			if idx != -1 {
+				transformersCount = float64(len(cfg[idx].Transformers))
+			}
+
+			// scores = relSize + (realSize * 0.03 * transformersCount)
+			t.Scores = t.Size + int64(float64(t.Size)*defaultTransformerCostMultiplier*transformersCount)
+		}
+
+	}
+
+	slices.SortFunc(dataSectionObjects, func(a, b entries.Entry) int {
+		var scoresA, scoresB int64
+		t, ok := a.(*entries.Table)
+		if ok {
+			scoresA = t.Scores
+		}
+		t, ok = b.(*entries.Table)
+		if ok {
+			scoresB = t.Scores
+		}
+
+		if scoresA > scoresB {
+			return -1
+		} else if scoresA < scoresB {
+			return 1
+		}
+		return 0
+	})
+
 }

--- a/internal/db/postgres/context/queries.go
+++ b/internal/db/postgres/context/queries.go
@@ -25,9 +25,9 @@ var (
 		   c.relname                              as "Name",
 		   pg_catalog.pg_get_userbyid(c.relowner) as "Owner",
 		   c.relkind 							  as "RelKind",
-		   (coalesce(pn.nspname, '')) 			  as "rootPtSchema",
-		   (coalesce(pc.relname, '')) 			  as "rootPtName",
-		   (coalesce(pc.oid, 0))::TEXT::INT       as "rootOid"
+		   (coalesce(pn.nspname, '')) 			  as "RootPtSchema",
+		   (coalesce(pc.relname, '')) 			  as "RootPtName",
+		   (coalesce(pc.oid, 0))::TEXT::INT       as "RootOid"
         FROM pg_catalog.pg_class c
 				JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
                 LEFT JOIN pg_catalog.pg_inherits i ON i.inhrelid = c.oid

--- a/internal/db/postgres/entries/table.go
+++ b/internal/db/postgres/entries/table.go
@@ -44,6 +44,7 @@ type Table struct {
 	Driver               *toolkit.Driver
 	// ValidateLimitedRecords - perform dumping and transformation only for N records and exit
 	ValidateLimitedRecords uint64
+	Scores                 int64
 }
 
 func (t *Table) HasCustomTransformer() bool {

--- a/pkg/toolkit/table.go
+++ b/pkg/toolkit/table.go
@@ -24,6 +24,7 @@ type Table struct {
 	Kind        string       `json:"kind"`
 	Parent      Oid          `json:"parent"`
 	Children    []Oid        `json:"children"`
+	Size        int64        `json:"size"`
 	Constraints []Constraint `json:"-"`
 }
 


### PR DESCRIPTION
* Added tables scoring according to their size and transformation count. It should help to distribute the dumper tasks equally to the workers (#50). The transformer score is 0.03 for table size
* Fixed pgx rows object leakage during the schema introspection stage