### PR TITLE
Remove bucket name from object path prefix

### DIFF
--- a/internal/storages/s3/s3.go
+++ b/internal/storages/s3/s3.go
@@ -165,7 +165,7 @@ func NewStorage(ctx context.Context, cfg *Config, logLevel string) (*Storage, er
 		Msg("s3 storage bucket")
 
 	return &Storage{
-		prefix:   fixPrefix(path.Join(cfg.Bucket, cfg.Prefix)),
+		prefix:   fixPrefix(cfg.Prefix),
 		session:  ses,
 		config:   cfg,
 		service:  service,


### PR DESCRIPTION
Current implementation is duplicating the bucket name in the object path prefix:
![image](https://github.com/GreenmaskIO/greenmask/assets/11475695/133dc394-fcbe-4d37-a38b-ea289e567c06)

This PR removes the bucket name from the prefix, which was being unnecessarily added.

As a suggestion: I was thinking further on this and it would be nice to have a default path prefix definition that includes the db host and db name to avoid confusion in case one just decides to dump multiple database dumps into the same bucket without defining a prefix.

Something like:
`STORAGE_S3_PREFIX / DB_HOSTNAME-DB_NAME / DUMP_ID`
Where it would be possible to set another config value (ie. `STORAGE_S3_PATH` or some other naming to avoid confusion) to override the `DB_HOSTNAME-DB_NAME` string.

This would result in:
- defining only the bucket would "just work" with logical separation of multiple databases in the same bucket
- defining a prefix would be ideal for the use case where one does not have a bucket exclusively for Greenmask dumps, but still doesn't need to "manually" define prefixes for each database
- possibility to override the the default path based on database/host if needed