### PR TITLE
change docker workdir to greenmask home

### DIFF
--- a/docker/greenmask/Dockerfile
+++ b/docker/greenmask/Dockerfile
@@ -45,4 +45,6 @@ RUN mkdir ~/.bash_completions \
     && echo 'source /etc/bash_completion' >> ~/.bashrc \
     && echo 'source ~/.bash_completions/greenmask.bash' >> ~/.bashrc
 
+WORKDIR /home/greenmask
+
 ENTRYPOINT ["greenmask"]


### PR DESCRIPTION
- Changes Dockerfile `WORKDIR` to `/home/greenmask`

Found this minor issue while testing