### PR TITLE
Adapted table size calculation with TOAST.

### DIFF
--- a/internal/db/postgres/context/pg_catalog.go
+++ b/internal/db/postgres/context/pg_catalog.go
@@ -361,7 +361,13 @@ func BuildTableSearchQuery(
 		   n.nspname                              as "Schema",
 		   c.relname                              as "Name",
 		   pg_catalog.pg_get_userbyid(c.relowner) as "Owner",
-		   pg_catalog.pg_relation_size(c.oid)     as "Size",
+		   pg_catalog.pg_relation_size(c.oid) + 
+		   		coalesce(
+		   			pg_catalog.pg_relation_size(
+		   				c.reltoastrelid
+		   			), 
+		   			0
+		   		) 							      as "Size",
 		   c.relkind 							  as "RelKind",
 		   (coalesce(pn.nspname, '')) 			  as "rootPtSchema",
 		   (coalesce(pc.relname, '')) 			  as "rootPtName",


### PR DESCRIPTION
The table's calculation size now is `pg_relation_size(oid) + pg_relation_size(reltoastrelid)`. We would use `pg_relation_size` but we need to exclude index size because we dump only the index DLL statement.

Resolves #50