### PR TITLE
add prefix to storage config

### DIFF
--- a/internal/domains/config.go
+++ b/internal/domains/config.go
@@ -83,6 +83,7 @@ type Common struct {
 
 type StorageConfig struct {
 	Type      string            `mapstructure:"type" yaml:"type" json:"type,omitempty"`
+	Prefix    string            `mapstructure:"prefix" yaml:"prefix" json:"prefix,omitempty"`
 	S3        *s3.Config        `mapstructure:"s3"  json:"s3,omitempty" yaml:"s3"`
 	Directory *directory.Config `mapstructure:"directory" json:"directory,omitempty" yaml:"directory"`
 }

--- a/internal/storages/builder/builder.go
+++ b/internal/storages/builder/builder.go
@@ -38,9 +38,9 @@ func GetStorage(ctx context.Context, stCfg *domains.StorageConfig, logCgf *domai
 		if err := stCfg.Directory.Validate(); err != nil {
 			return nil, fmt.Errorf("directory storage config validation failed: %w", err)
 		}
-		return directory.NewStorage(stCfg.Directory)
+		return directory.NewStorage(stCfg.Directory, stCfg.Prefix)
 	case S3StorageType:
-		return s3.NewStorage(ctx, stCfg.S3, logCgf.Level)
+		return s3.NewStorage(ctx, stCfg.S3, stCfg.Prefix, logCgf.Level)
 	}
 	return nil, fmt.Errorf("unknown storage type: %s", stCfg.Type)
 }

--- a/internal/storages/directory/directiry_test.go
+++ b/internal/storages/directory/directiry_test.go
@@ -26,7 +26,7 @@ func (suite *DirectorySuite) SetupSuite() {
 	suite.tmpDir, err = os.MkdirTemp(tempDir, "directory_storage_unit_test_")
 	suite.Require().NoError(err)
 
-	suite.st, err = NewStorage(&Config{Path: suite.tmpDir})
+	suite.st, err = NewStorage(&Config{Path: suite.tmpDir}, "")
 	suite.Require().NoError(err)
 }
 

--- a/internal/storages/directory/directory.go
+++ b/internal/storages/directory/directory.go
@@ -40,7 +40,7 @@ type Storage struct {
 	mx       sync.Mutex
 }
 
-func NewStorage(cfg *Config) (*Storage, error) {
+func NewStorage(cfg *Config, prefix string) (*Storage, error) {
 	// TODO: We would replace hardcoded file mask to Umask for unix system
 	fileInfo, err := os.Stat(cfg.Path)
 	if err != nil {
@@ -52,7 +52,7 @@ func NewStorage(cfg *Config) (*Storage, error) {
 	return &Storage{
 		dirMode:  dirMode,
 		fileMode: fileMode,
-		cwd:      cfg.Path,
+		cwd:      fmt.Sprintf("%s/%s", prefix, cfg.Path),
 	}, nil
 }
 

--- a/internal/storages/directory/directory.go
+++ b/internal/storages/directory/directory.go
@@ -52,7 +52,7 @@ func NewStorage(cfg *Config, prefix string) (*Storage, error) {
 	return &Storage{
 		dirMode:  dirMode,
 		fileMode: fileMode,
-		cwd:      fmt.Sprintf("%s/%s", prefix, cfg.Path),
+		cwd:      path.Join(fixPrefix(prefix), cfg.Path),
 	}, nil
 }
 
@@ -187,4 +187,11 @@ func (d *Storage) SubStorage(dp string, relative bool) storages.Storager {
 		dirMode:  d.dirMode,
 		fileMode: d.fileMode,
 	}
+}
+
+func fixPrefix(prefix string) string {
+	if prefix != "" && prefix[len(prefix)-1] != '/' {
+		prefix = prefix + "/"
+	}
+	return prefix
 }

--- a/internal/storages/s3/config.go
+++ b/internal/storages/s3/config.go
@@ -24,7 +24,6 @@ const (
 type Config struct {
 	Endpoint         string `mapstructure:"endpoint"`
 	Bucket           string `mapstructure:"bucket"`
-	Prefix           string `mapstructure:"prefix"`
 	Region           string `mapstructure:"region"`
 	StorageClass     string `mapstructure:"storage_class"`
 	DisableSSL       bool   `mapstructure:"disable_ssl"`

--- a/internal/storages/s3/s3.go
+++ b/internal/storages/s3/s3.go
@@ -60,7 +60,7 @@ type Storage struct {
 	delimiter string
 }
 
-func NewStorage(ctx context.Context, cfg *Config, logLevel string) (*Storage, error) {
+func NewStorage(ctx context.Context, cfg *Config, prefix string, logLevel string) (*Storage, error) {
 
 	ses, err := session.NewSession()
 	if err != nil {
@@ -165,7 +165,7 @@ func NewStorage(ctx context.Context, cfg *Config, logLevel string) (*Storage, er
 		Msg("s3 storage bucket")
 
 	return &Storage{
-		prefix:   fixPrefix(cfg.Prefix),
+		prefix:   fixPrefix(prefix),
 		session:  ses,
 		config:   cfg,
 		service:  service,


### PR DESCRIPTION
- move `storage.s3.prefix` to `storage.prefix`
- prefix now works with directory storage
- prefix should have the same functionality in s3 storage

closes #69