### PR TITLE
Fix: viper and mapstructure limitation workaround

### DIFF
--- a/cmd/greenmask/cmd/root.go
+++ b/cmd/greenmask/cmd/root.go
@@ -145,4 +145,10 @@ func initConfig() {
 	if err := viper.Unmarshal(Config, decoderCfg); err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
+
+	// This solves problem with map structure described -> https://github.com/spf13/viper/issues/373
+	// that caused issue in Greenmask https://github.com/GreenmaskIO/greenmask/issues/76
+	if err := configUtils.ParseTransformerParamsManually(cfgFile, Config); err != nil {
+		log.Fatal().Err(err).Msg("error parsing transformer parameters")
+	}
 }

--- a/internal/domains/config.go
+++ b/internal/domains/config.go
@@ -110,7 +110,15 @@ type TransformerSettings struct {
 type TransformerConfig struct {
 	Name     string               `mapstructure:"name" yaml:"name" json:"name,omitempty"`
 	Settings *TransformerSettings `mapstructure:"settings,omitempty" yaml:"settings,omitempty" json:"settings,omitempty"`
-	Params   toolkit.Params       `mapstructure:"params" yaml:"params" json:"params,omitempty"`
+	// Params - transformation parameters. It might be any type. If structure should be stored as raw json
+	// This cannot be parsed with mapstructure due to uncontrollable lowercasing
+	// https://github.com/spf13/viper/issues/373
+	// Instead we have to use workaround and parse it manually
+	Params toolkit.Params `mapstructure:"-" yaml:"-" json:"-"` // yaml:"params" json:"params,omitempty"`
+	// TempParams - the https://github.com/spf13/viper/issues/373 workaround
+	// we decode the values into TempParams and then Unmarshal it manually and set to Params
+	// The related code is in internal/utils/config/viper_workaround.go
+	TempParams map[string]any `mapstructure:"-" yaml:"params,omitempty" json:"params,omitempty"`
 }
 
 type Table struct {

--- a/internal/utils/config/viper_workaround.go
+++ b/internal/utils/config/viper_workaround.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/greenmaskio/greenmask/internal/domains"
+	"github.com/greenmaskio/greenmask/pkg/toolkit"
+)
+
+// ParseTransformerParamsManually - manually parse dump.transformation[a].transformers[b].params
+// The problem described https://github.com/GreenmaskIO/greenmask/issues/76
+// We need to keep the original keys in the map without lowercasing
+// To overcome this problem we need use default yaml and json parsers avoiding vaiper or mapstructure usage.
+func ParseTransformerParamsManually(cfgFilePath string, cfg *domains.Config) error {
+	ext := path.Ext(cfgFilePath)
+	//cfgMap := make(map[string]any)
+	tmpCfg := domains.NewConfig()
+	f, err := os.Open(cfgFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	switch ext {
+	case ".json":
+		if err = json.NewDecoder(f).Decode(&tmpCfg); err != nil {
+			return err
+		}
+	case ".yaml", ".yml":
+		if err = yaml.NewDecoder(f).Decode(&tmpCfg); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported file extension \"%s\"", err)
+	}
+	return setTransformerParams(tmpCfg, cfg)
+}
+
+// setTransformerParams - get the value from domains.TransformerConfig.TempParams, marshall this value and store into
+// domains.TransformerConfig.Params
+func setTransformerParams(tmpCfg, cfg *domains.Config) (err error) {
+	for tableIdx, tableObj := range tmpCfg.Dump.Transformation {
+		for transformationIdx, transformationObj := range tableObj.Transformers {
+			transformer := cfg.Dump.Transformation[tableIdx].Transformers[transformationIdx]
+			paramsMap := make(map[string]toolkit.ParamsValue, len(transformationObj.Params))
+			for paramName, decodedValue := range transformer.TempParams {
+				var encodedVal toolkit.ParamsValue
+				switch v := decodedValue.(type) {
+				case string:
+					encodedVal = toolkit.ParamsValue(v)
+				default:
+					encodedVal, err = json.Marshal(v)
+					if err != nil {
+						return fmt.Errorf("cannot convert object to json bytes: %w", err)
+					}
+				}
+				paramsMap[paramName] = encodedVal
+			}
+			transformer.Params = paramsMap
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This solves the problem with the map structure described -> https://github.com/spf13/viper/issues/373 that caused the issue in Greenmask #76

We need to keep the original keys in the map without lowercasing. To overcome this problem we need to use default `yaml` and `json` parsers to avoid viper or mapstructure usage

The related viper [issue](https://github.com/spf13/viper/issues/373)