### PR TITLE
feat: restore data in batches

### DIFF
--- a/cmd/greenmask/cmd/restore/restore.go
+++ b/cmd/greenmask/cmd/restore/restore.go
@@ -171,6 +171,10 @@ func init() {
 		"pgzip", "", false,
 		"use pgzip decompression instead of gzip",
 	)
+	Cmd.Flags().Int64P(
+		"batch-size", "", 0,
+		"the number of rows to insert in a single batch during the COPY command (0 - all rows will be inserted in a single batch)",
+	)
 
 	// Connection options:
 	Cmd.Flags().StringP("host", "h", "/var/run/postgres", "database server host or socket directory")
@@ -185,7 +189,7 @@ func init() {
 		"disable-triggers", "enable-row-security", "if-exists", "no-comments", "no-data-for-failed-tables",
 		"no-security-labels", "no-subscriptions", "no-table-access-method", "no-tablespaces", "section",
 		"strict-names", "use-set-session-authorization", "inserts", "on-conflict-do-nothing", "restore-in-order",
-		"pgzip",
+		"pgzip", "batch-size",
 
 		"host", "port", "username",
 	} {

--- a/internal/db/postgres/cmd/restore.go
+++ b/internal/db/postgres/cmd/restore.go
@@ -646,7 +646,9 @@ func (r *Restore) taskPusher(ctx context.Context, tasks chan restorers.RestoreTa
 							r.cfg.ErrorExclusions, r.restoreOpt.Pgzip,
 						)
 					} else {
-						task = restorers.NewTableRestorer(entry, r.st, r.restoreOpt.ExitOnError, r.restoreOpt.Pgzip)
+						task = restorers.NewTableRestorer(
+							entry, r.st, r.restoreOpt.ExitOnError, r.restoreOpt.Pgzip, r.restoreOpt.BatchSize,
+						)
 					}
 
 				case toc.SequenceSetDesc:

--- a/internal/db/postgres/cmd/validate.go
+++ b/internal/db/postgres/cmd/validate.go
@@ -223,7 +223,7 @@ func (v *Validate) readRecords(r *bufio.Reader, t *entries.Table) (original, tra
 	originalRow = pgcopy.NewRow(len(t.Columns))
 	transformedRow = pgcopy.NewRow(len(t.Columns))
 
-	originalLine, err = reader.ReadLine(r)
+	originalLine, err = reader.ReadLine(r, nil)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, nil, err
@@ -235,7 +235,7 @@ func (v *Validate) readRecords(r *bufio.Reader, t *entries.Table) (original, tra
 		return nil, nil, io.EOF
 	}
 
-	transformedLine, err = reader.ReadLine(r)
+	transformedLine, err = reader.ReadLine(r, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read line: %w", err)
 	}

--- a/internal/db/postgres/pgrestore/pgrestore.go
+++ b/internal/db/postgres/pgrestore/pgrestore.go
@@ -97,7 +97,8 @@ type Options struct {
 	Inserts             bool `mapstructure:"inserts"`
 	RestoreInOrder      bool `mapstructure:"restore-in-order"`
 	// Use pgzip decompression instead of gzip
-	Pgzip bool `mapstructure:"pgzip"`
+	Pgzip     bool  `mapstructure:"pgzip"`
+	BatchSize int64 `mapstructure:"batch-size"`
 
 	// Connection options:
 	Host       string `mapstructure:"host"`

--- a/internal/db/postgres/restorers/table_insert_format.go
+++ b/internal/db/postgres/restorers/table_insert_format.go
@@ -140,7 +140,7 @@ func (td *TableRestorerInsertFormat) streamInsertData(ctx context.Context, conn 
 		default:
 		}
 
-		line, err := reader.ReadLine(buf)
+		line, err := reader.ReadLine(buf, nil)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/internal/db/postgres/transformers/custom/dynamic_definition.go
+++ b/internal/db/postgres/transformers/custom/dynamic_definition.go
@@ -85,7 +85,7 @@ func GetDynamicTransformerDefinition(ctx context.Context, executable string, arg
 
 				buf := bufio.NewReader(bytes.NewBuffer(stdoutData))
 				for {
-					line, err := reader.ReadLine(buf)
+					line, err := reader.ReadLine(buf, nil)
 					if err != nil {
 						break
 					}
@@ -102,7 +102,7 @@ func GetDynamicTransformerDefinition(ctx context.Context, executable string, arg
 
 				buf := bufio.NewReader(bytes.NewBuffer(stderrData))
 				for {
-					line, err := reader.ReadLine(buf)
+					line, err := reader.ReadLine(buf, nil)
 					if err != nil {
 						break
 					}

--- a/internal/db/postgres/transformers/utils/cmd_transformer_base.go
+++ b/internal/db/postgres/transformers/utils/cmd_transformer_base.go
@@ -315,7 +315,7 @@ func (ctb *CmdTransformerBase) init() error {
 
 func (ctb *CmdTransformerBase) ReceiveStderrLine(ctx context.Context) (line []byte, err error) {
 	go func() {
-		line, err = reader.ReadLine(ctb.StderrReader)
+		line, err = reader.ReadLine(ctb.StderrReader, nil)
 		ctb.receiveChan <- struct{}{}
 	}()
 	select {
@@ -333,7 +333,7 @@ func (ctb *CmdTransformerBase) ReceiveStderrLine(ctx context.Context) (line []by
 
 func (ctb *CmdTransformerBase) ReceiveStdoutLine(ctx context.Context) (line []byte, err error) {
 	go func() {
-		line, err = reader.ReadLine(ctb.StdoutReader)
+		line, err = reader.ReadLine(ctb.StdoutReader, nil)
 		ctb.receiveChan <- struct{}{}
 	}()
 	select {

--- a/internal/utils/cmd_runner/cmd_runner.go
+++ b/internal/utils/cmd_runner/cmd_runner.go
@@ -53,7 +53,7 @@ func Run(ctx context.Context, logger *zerolog.Logger, name string, args ...strin
 				return gtx.Err()
 			default:
 			}
-			line, err := reader.ReadLine(lineScanner)
+			line, err := reader.ReadLine(lineScanner, nil)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return nil
@@ -73,7 +73,7 @@ func Run(ctx context.Context, logger *zerolog.Logger, name string, args ...strin
 				return gtx.Err()
 			default:
 			}
-			line, err := reader.ReadLine(lineScanner)
+			line, err := reader.ReadLine(lineScanner, nil)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return nil

--- a/internal/utils/reader/reader.go
+++ b/internal/utils/reader/reader.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 )
 
-func ReadLine(r *bufio.Reader) ([]byte, error) {
-	var res []byte
+func ReadLine(r *bufio.Reader, buf []byte) ([]byte, error) {
+	buf = buf[:0]
 	for {
 		var line []byte
 		line, isPrefix, err := r.ReadLine()
 		if err != nil {
 			return nil, fmt.Errorf("unable to read line: %w", err)
 		}
-		res = append(res, line...)
+		buf = append(buf, line...)
 		if !isPrefix {
 			break
 		}
 	}
-	return res, nil
+	return buf, nil
 }


### PR DESCRIPTION
* Introduced the --batch-size flag for the restore command.
* The COPY command will complete after reaching the specified batch size, allowing for transaction state checks.
* The transaction spans across all batches.
* If an error occurs in any batch, all previous batches will be rolled back.