### PR TITLE
fix: Dump/Restore fails when masking tables with a generated column

### DIFF
--- a/cmd/greenmask/cmd/restore/restore.go
+++ b/cmd/greenmask/cmd/restore/restore.go
@@ -175,6 +175,10 @@ func init() {
 		"batch-size", "", 0,
 		"the number of rows to insert in a single batch during the COPY command (0 - all rows will be inserted in a single batch)",
 	)
+	Cmd.Flags().BoolP(
+		"overriding-system-value", "", false,
+		"use OVERRIDING SYSTEM VALUE clause for INSERTs",
+	)
 
 	// Connection options:
 	Cmd.Flags().StringP("host", "h", "/var/run/postgres", "database server host or socket directory")
@@ -189,7 +193,7 @@ func init() {
 		"disable-triggers", "enable-row-security", "if-exists", "no-comments", "no-data-for-failed-tables",
 		"no-security-labels", "no-subscriptions", "no-table-access-method", "no-tablespaces", "section",
 		"strict-names", "use-set-session-authorization", "inserts", "on-conflict-do-nothing", "restore-in-order",
-		"pgzip", "batch-size",
+		"pgzip", "batch-size", "overriding-system-value",
 
 		"host", "port", "username",
 	} {

--- a/docker/integration/filldb/.dockerignore
+++ b/docker/integration/filldb/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/docker/integration/filldb/Dockerfile
+++ b/docker/integration/filldb/Dockerfile
@@ -8,7 +8,7 @@ ENV TMP_DIR=/tmp/schema
 
 RUN apt-get update && apt-get install -y wget && mkdir /tmp/schema
 
-COPY filldb.sh /filldb.sh
+COPY . /
 
 RUN chmod +x ./filldb.sh
 

--- a/docker/integration/filldb/filldb.sh
+++ b/docker/integration/filldb/filldb.sh
@@ -15,13 +15,18 @@
 
 cd $TMP_DIR
 if [ ! -f $FILE_DUMP ]; then
+    echo "Downloading dump file"
     wget https://edu.postgrespro.com/$FILE_DUMP
 fi
 IFS="," read -ra PG_VERSIONS_CHECK <<< "${PG_VERSIONS_CHECK}"
 for pgver in ${PG_VERSIONS_CHECK[@]}; do
+  echo "Restoring database for PostgreSQL $pgver"
   if  psql -p 5432 -h db-$pgver -U postgres -c 'CREATE DATABASE demo;'; then
     psql -p 5432 -h db-$pgver -U postgres -c 'DROP DATABASE demo_restore;'
     psql -p 5432 -h db-$pgver -U postgres -c 'CREATE DATABASE demo_restore;'
     gzip -dc $FILE_DUMP | psql -p 5432 -h db-$pgver -U postgres -d demo
+    if [ $pgver -ne '11' ]; then
+       psql -p 5432 -h db-$pgver -U postgres -d demo -f /generated.sql
+    fi
   fi
 done

--- a/docker/integration/filldb/generated.sql
+++ b/docker/integration/filldb/generated.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.people
+(
+    id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    generated  text GENERATED ALWAYS AS (id || first_name) STORED,
+    first_name text
+);
+
+INSERT INTO public.people("first_name")
+VALUES ('bob');

--- a/internal/db/postgres/cmd/restore.go
+++ b/internal/db/postgres/cmd/restore.go
@@ -651,7 +651,7 @@ func (r *Restore) taskPusher(ctx context.Context, tasks chan restorers.RestoreTa
 						}
 						task = restorers.NewTableRestorerInsertFormat(
 							entry, t, r.st, r.restoreOpt.ExitOnError, r.restoreOpt.OnConflictDoNothing,
-							r.cfg.ErrorExclusions, r.restoreOpt.Pgzip,
+							r.cfg.ErrorExclusions, r.restoreOpt.Pgzip, r.restoreOpt.OverridingSystemValue,
 						)
 					} else {
 						task = restorers.NewTableRestorer(

--- a/internal/db/postgres/cmd/restore.go
+++ b/internal/db/postgres/cmd/restore.go
@@ -36,13 +36,13 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 
-	"github.com/greenmaskio/greenmask/internal/domains"
-
 	"github.com/greenmaskio/greenmask/internal/db/postgres/pgrestore"
 	"github.com/greenmaskio/greenmask/internal/db/postgres/restorers"
 	"github.com/greenmaskio/greenmask/internal/db/postgres/storage"
 	"github.com/greenmaskio/greenmask/internal/db/postgres/toc"
+	"github.com/greenmaskio/greenmask/internal/domains"
 	"github.com/greenmaskio/greenmask/internal/storages"
+	"github.com/greenmaskio/greenmask/pkg/toolkit"
 )
 
 const (
@@ -71,6 +71,10 @@ const (
 const metadataObjectName = "metadata.json"
 
 const dependenciesCheckInterval = 15 * time.Millisecond
+
+var (
+	ErrTableDefinitionIsEmtpy = errors.New("table definition is empty: please re-dump the data using the latest version of greenmask if you want to use --inserts")
+)
 
 type Restore struct {
 	binPath    string
@@ -641,8 +645,12 @@ func (r *Restore) taskPusher(ctx context.Context, tasks chan restorers.RestoreTa
 				switch *entry.Desc {
 				case toc.TableDataDesc:
 					if r.restoreOpt.Inserts || r.restoreOpt.OnConflictDoNothing {
+						t, err := r.getTableDefinitionFromMeta(entry.DumpId)
+						if err != nil {
+							return fmt.Errorf("cannot get table definition from meta: %w", err)
+						}
 						task = restorers.NewTableRestorerInsertFormat(
-							entry, r.st, r.restoreOpt.ExitOnError, r.restoreOpt.OnConflictDoNothing,
+							entry, t, r.st, r.restoreOpt.ExitOnError, r.restoreOpt.OnConflictDoNothing,
 							r.cfg.ErrorExclusions, r.restoreOpt.Pgzip,
 						)
 					} else {
@@ -669,6 +677,20 @@ func (r *Restore) taskPusher(ctx context.Context, tasks chan restorers.RestoreTa
 		}
 		return nil
 	}
+}
+
+func (r *Restore) getTableDefinitionFromMeta(dumpId int32) (*toolkit.Table, error) {
+	tableOid, ok := r.metadata.DumpIdsToTableOid[dumpId]
+	if !ok {
+		return nil, ErrTableDefinitionIsEmtpy
+	}
+	idx := slices.IndexFunc(r.metadata.DatabaseSchema, func(t *toolkit.Table) bool {
+		return t.Oid == tableOid
+	})
+	if idx == -1 {
+		panic(fmt.Sprintf("table with oid %d is not found in metadata", tableOid))
+	}
+	return r.metadata.DatabaseSchema[idx], nil
 }
 
 func (r *Restore) restoreWorker(ctx context.Context, tasks <-chan restorers.RestoreTask, id int) error {

--- a/internal/db/postgres/context/pg_catalog.go
+++ b/internal/db/postgres/context/pg_catalog.go
@@ -158,7 +158,7 @@ func getTables(
 			// Columns were already initialized during the transformer initialization
 			continue
 		}
-		columns, err := getColumnsConfig(ctx, tx, t.Oid, version)
+		columns, err := getColumnsConfig(ctx, tx, t.Oid, version, true)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to collect table columns: %w", err)
 		}

--- a/internal/db/postgres/context/schema.go
+++ b/internal/db/postgres/context/schema.go
@@ -41,7 +41,8 @@ func getDatabaseSchema(
 
 	// fill columns
 	for _, table := range res {
-		columns, err := getColumnsConfig(ctx, tx, table.Oid, version)
+		// We do not exclude generated columns here, because the schema must be compared with the original
+		columns, err := getColumnsConfig(ctx, tx, table.Oid, version, false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/postgres/entries/table.go
+++ b/internal/db/postgres/entries/table.go
@@ -130,6 +130,8 @@ func (t *Table) Entry() (*toc.Entry, error) {
 }
 
 func (t *Table) GetCopyFromStatement() (string, error) {
+	// We could generate an explicit column list for the COPY statement, but it’s not necessary because, by default,
+	// generated columns are excluded from the COPY operation.
 	query := fmt.Sprintf("COPY \"%s\".\"%s\" TO STDOUT", t.Schema, t.Name)
 	if t.Query != "" {
 		query = fmt.Sprintf("COPY (%s) TO STDOUT", t.Query)

--- a/internal/db/postgres/pgrestore/pgrestore.go
+++ b/internal/db/postgres/pgrestore/pgrestore.go
@@ -96,6 +96,8 @@ type Options struct {
 	OnConflictDoNothing bool `mapstructure:"on-conflict-do-nothing"`
 	Inserts             bool `mapstructure:"inserts"`
 	RestoreInOrder      bool `mapstructure:"restore-in-order"`
+	// OverridingSystemValue is a custom option that allows to use OVERRIDING SYSTEM VALUE for INSERTs
+	OverridingSystemValue bool `mapstructure:"overriding-system-value"`
 	// Use pgzip decompression instead of gzip
 	Pgzip     bool  `mapstructure:"pgzip"`
 	BatchSize int64 `mapstructure:"batch-size"`


### PR DESCRIPTION
* Added attributes for metadata handling.
* The restore command now retrieves table definitions from metadata in storage.
* introduced a new option for `restore` command `--overriding-system-value`. if `--inserts` option is provided generates `INSERT` statements with ` OVERRIDING SYSTEM VALUE VALUES`
* Generated columns in `toolkit.Table` are now excluded from the Columns list
* Grouped imports
* Added integration test for generated columns

Closes #183

Co-authored-by: @vinnyjth