### PR TITLE
fix `fatal validation error` in playground

### DIFF
--- a/playground/config.yml
+++ b/playground/config.yml
@@ -26,7 +26,7 @@ dump:
       transformers: # List of transformers to apply
         - name: "NoiseDate" # name of transformers
           params: # Transformer parameters
-            ratio: "10 year 9 mon 1 day"
+            max_ratio: "10 year 9 mon 1 day"
             column: "birthdate" # Column parameter - this transformer affects scheduled_departure column
 
 restore:


### PR DESCRIPTION
running the playground currently causes the following error:

```
 ERR ValidationWarning={"hash":"300b59e1e8f328f868bd32b03c1af0f0","meta":{"ParameterName":"max_ratio","SchemaName":"humanresources","TableName":"employee","TransformerName":"NoiseDate"},"msg":"parameter is required","severity":"error"}
2024-10-22T06:25:13Z FTL error="fatal validation error"
```

this change follows the required params as per the [docs](https://docs.greenmask.io/latest/built_in_transformers/standard_transformers/noise_date/#parameters)