### PR TITLE
fix: removed transformers validation that does not have apply_for_references

### DIFF
--- a/internal/db/postgres/context/config_builder.go
+++ b/internal/db/postgres/context/config_builder.go
@@ -543,6 +543,9 @@ func checkApplyForReferenceMetRequirements(
 ) (bool, toolkit.ValidationWarnings) {
 	warnings := toolkit.ValidationWarnings{}
 	for _, tr := range tcm.config.Transformers {
+		if !tr.ApplyForReferences {
+			continue
+		}
 		allowed, w := isTransformerAllowedToApplyForReferences(tr, r)
 		if !allowed {
 			warnings = append(warnings, w...)


### PR DESCRIPTION
fix: removed transformers validation that does not have apply_for_references

* Skip transformers validation when not apply_for_references
* Add regression test

Closes #235 