### PR TITLE
Fix: Addressed bugs related to partitioned tables

### DIFF
--- a/docs/built_in_transformers/transformation_inheritance.md
+++ b/docs/built_in_transformers/transformation_inheritance.md
@@ -172,8 +172,8 @@ configuration:
   transformers:
     - name: RandomDate
       params:
-        min: "2000-01-01"
-        max: "2005-01-01"
+        min: "2022-01-01"
+        max: "2022-03-01"
         column: "sale_date"
         engine: "random"
 ```

--- a/internal/db/postgres/cmd/dump.go
+++ b/internal/db/postgres/cmd/dump.go
@@ -328,7 +328,11 @@ func (d *Dump) createTocEntries() error {
 				Original:   v.OriginalSize,
 				Compressed: v.CompressedSize,
 			}
-			tablesEntry = append(tablesEntry, entry)
+			if v.RelKind != 'p' {
+				// Do not create TOC entry for partitioned tables because they are not dumped. Only their partitions are
+				// dumped
+				tablesEntry = append(tablesEntry, entry)
+			}
 			tables = append(tables, v)
 		case *entries.Sequence:
 			sequences = append(sequences, entry)
@@ -529,7 +533,7 @@ func (d *Dump) MergeTocEntries(schemaEntries []*toc.Entry, dataEntries []*toc.En
 	res := make([]*toc.Entry, 0, len(schemaEntries)+len(dataEntries))
 
 	preDataEnd := 0
-	postDataStart := 0
+	postDataStart := len(schemaEntries) - 1
 
 	// Find predata last index and postdata first index
 	for idx, item := range schemaEntries {

--- a/internal/db/postgres/context/config_builder.go
+++ b/internal/db/postgres/context/config_builder.go
@@ -408,7 +408,7 @@ func isEndToEndPKFK(graph *subset.Graph, table *entries.Table) bool {
 	return foundInFK
 }
 
-func findPartitionsOfPartitionedTable(ctx context.Context, tx pgx.Tx, t *entries.Table) ([]toolkit.Oid, error) {
+func findPartitionsOfPartitionedTable(ctx context.Context, tx pgx.Tx, t *toolkit.Table) ([]toolkit.Oid, error) {
 	log.Debug().
 		Str("TableSchema", t.Schema).
 		Str("TableName", t.Name).
@@ -615,7 +615,7 @@ func checkTransformerAlreadyExists(
 func setupConfigForPartitionedTableChildren(
 	ctx context.Context, tx pgx.Tx, parentTcm *tableConfigMapping, tables []*entries.Table, cfg []*domains.Table,
 ) ([]*tableConfigMapping, error) {
-	parts, err := findPartitionsOfPartitionedTable(ctx, tx, parentTcm.entry)
+	parts, err := findPartitionsOfPartitionedTable(ctx, tx, parentTcm.entry.Table)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"cannot find partitions of the table %s.%s: %w",

--- a/internal/db/postgres/context/schema.go
+++ b/internal/db/postgres/context/schema.go
@@ -2,8 +2,10 @@ package context
 
 import (
 	"context"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog/log"
 
 	"github.com/greenmaskio/greenmask/internal/db/postgres/pgdump"
 	"github.com/greenmaskio/greenmask/pkg/toolkit"
@@ -12,7 +14,7 @@ import (
 func getDatabaseSchema(
 	ctx context.Context, tx pgx.Tx, options *pgdump.Options, version int,
 ) ([]*toolkit.Table, error) {
-	var res []*toolkit.Table
+	var tables []*toolkit.Table
 	query, err := buildSchemaIntrospectionQuery(
 		options.Table, options.ExcludeTable,
 		options.IncludeForeignData, options.Schema,
@@ -36,11 +38,11 @@ func getDatabaseSchema(
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, table)
+		tables = append(tables, table)
 	}
 
 	// fill columns
-	for _, table := range res {
+	for _, table := range tables {
 		// We do not exclude generated columns here, because the schema must be compared with the original
 		columns, err := getColumnsConfig(ctx, tx, table.Oid, version, false)
 		if err != nil {
@@ -49,5 +51,29 @@ func getDatabaseSchema(
 		table.Columns = columns
 	}
 
-	return res, nil
+	// 1. Find partitioned tables
+	// 2. Find all children of partitioned tables
+	// 3. Find children in the tables
+	// 4. Set RootPtSchema, RootPtName, RootPtOid for children
+	for _, table := range tables {
+		if table.Kind != "p" || table.Parent != 0 {
+			continue
+		}
+		for _, ptOId := range table.Children {
+			idx := slices.IndexFunc(tables, func(table *toolkit.Table) bool {
+				return table.Oid == ptOId
+			})
+			if idx == -1 {
+				log.Debug().
+					Int("TableOid", int(ptOId)).
+					Msg("table might be excluded: unable to find partitioned table")
+				continue
+			}
+			t := tables[idx]
+			t.RootPtName = table.Name
+			t.RootPtSchema = table.Schema
+			t.RootPtOid = table.Oid
+		}
+	}
+	return tables, nil
 }

--- a/internal/db/postgres/restorers/table_insert_format.go
+++ b/internal/db/postgres/restorers/table_insert_format.go
@@ -191,10 +191,18 @@ func (td *TableRestorerInsertFormat) generateInsertStmt(onConflictDoNothing bool
 		overridingSystemValue = "OVERRIDING SYSTEM VALUE "
 	}
 
+	tableName := *td.Entry.Tag
+	tableSchema := *td.Entry.Namespace
+
+	if td.Table.RootPtOid != 0 {
+		tableName = td.Table.RootPtName
+		tableSchema = td.Table.RootPtSchema
+	}
+
 	res := fmt.Sprintf(
 		`INSERT INTO %s.%s (%s) %sVALUES(%s)%s`,
-		*td.Entry.Namespace,
-		*td.Entry.Tag,
+		tableSchema,
+		tableName,
 		strings.Join(columnNames, ", "),
 		overridingSystemValue,
 		strings.Join(placeholders, ", "),

--- a/pkg/toolkit/table.go
+++ b/pkg/toolkit/table.go
@@ -26,16 +26,20 @@ type Reference struct {
 }
 
 type Table struct {
-	Schema      string       `json:"schema"`
-	Name        string       `json:"name"`
-	Oid         Oid          `json:"oid"`
-	Columns     []*Column    `json:"columns"`
-	Kind        string       `json:"kind"`
-	Parent      Oid          `json:"parent"`
-	Children    []Oid        `json:"children"`
-	Size        int64        `json:"size"`
-	PrimaryKey  []string     `json:"primary_key"`
-	Constraints []Constraint `json:"-"`
+	Schema     string    `json:"schema"`
+	Name       string    `json:"name"`
+	Oid        Oid       `json:"oid"`
+	Columns    []*Column `json:"columns"`
+	Kind       string    `json:"kind"`
+	Parent     Oid       `json:"parent"`
+	Children   []Oid     `json:"children"`
+	Size       int64     `json:"size"`
+	PrimaryKey []string  `json:"primary_key"`
+	// RootPtSchema, RootPtName, RootPtOid - the first parent of the partitioned table
+	RootPtSchema string       `json:"root_pt_schema"`
+	RootPtName   string       `json:"root_pt_name"`
+	RootPtOid    Oid          `json:"root_pt_oid"`
+	Constraints  []Constraint `json:"-"`
 }
 
 func (t *Table) Validate() error {


### PR DESCRIPTION
Closes #238

* Resolved an issue where `Dump.createTocEntries` processed partitioned tables as if they were physical entities, despite being logical.
* Refined the `findPartitionsOfPartitionedTable` function for improved accuracy.
* Corrected merging in the pre-data, data, and post-data sections, which previously caused a panic in dump command when the post-data section was excluded.
* Added metadata about the first parent root table in the `toolkit.Table` struct.
* Updated database schema metadata to include a root partition, which is necessary for performing `--inserts` during restoration.
* Fixed an issue where dumps created with `--load-via-partition-root` did not use the root partition table in `--inserts` generation during restoration.
* Revised a documentation example to ensure it aligns with table constraints.