### PR TITLE
Fix: Corrected naming in template context objects

### DIFF
--- a/internal/db/postgres/transformers/column_context.go
+++ b/internal/db/postgres/transformers/column_context.go
@@ -49,15 +49,15 @@ func (cc *ColumnContext) GetValue() (any, error) {
 }
 
 func (cc *ColumnContext) GetRawValue() (any, error) {
-	return cc.rc.GetColumnRawValue(cc.columnName)
+	return cc.rc.GetRawColumnValue(cc.columnName)
 }
 
 func (cc *ColumnContext) GetColumnValue(name string) (any, error) {
 	return cc.rc.GetColumnValue(name)
 }
 
-func (cc *ColumnContext) GetColumnRawValue(name string) (any, error) {
-	return cc.rc.GetColumnRawValue(name)
+func (cc *ColumnContext) GetRawColumnValue(name string) (any, error) {
+	return cc.rc.GetRawColumnValue(name)
 }
 
 func (cc *ColumnContext) EncodeValue(v any) (any, error) {

--- a/internal/db/postgres/transformers/email.go
+++ b/internal/db/postgres/transformers/email.go
@@ -150,7 +150,7 @@ func NewEmailTransformer(ctx context.Context, driver *toolkit.Driver, parameters
 		for _, c := range driver.Table.Columns {
 			funcMap[c.Name] = func(name string) func() (any, error) {
 				return func() (any, error) {
-					return rrctx.GetColumnRawValue(name)
+					return rrctx.GetRawColumnValue(name)
 				}
 			}(c.Name)
 		}

--- a/internal/db/postgres/transformers/json_context.go
+++ b/internal/db/postgres/transformers/json_context.go
@@ -46,8 +46,8 @@ func (jc *JsonContext) GetColumnValue(name string) (any, error) {
 	return jc.rc.GetColumnValue(name)
 }
 
-func (jc *JsonContext) GetColumnRawValue(name string) (any, error) {
-	return jc.rc.GetColumnRawValue(name)
+func (jc *JsonContext) GetRawColumnValue(name string) (any, error) {
+	return jc.rc.GetRawColumnValue(name)
 }
 
 func (jc *JsonContext) EncodeValueByColumn(name string, v any) (any, error) {

--- a/internal/db/postgres/transformers/template_record_test.go
+++ b/internal/db/postgres/transformers/template_record_test.go
@@ -86,7 +86,7 @@ func TestTemplateRecordTransformer_Transform_date(t *testing.T) {
 func TestTemplateRecordTransformer_Transform_json(t *testing.T) {
 	var columnName = "doc"
 	var template = `
-	  {{ $val := .GetColumnRawValue "doc" }}
+	  {{ $val := .GetRawColumnValue "doc" }}
 	  {{ jsonSet "name" "hello" $val | jsonValidate | .SetColumnValue "doc" }}
 	`
 

--- a/pkg/toolkit/dynamic_parameter.go
+++ b/pkg/toolkit/dynamic_parameter.go
@@ -53,15 +53,15 @@ func (dpc *DynamicParameterContext) GetValue() (any, error) {
 }
 
 func (dpc *DynamicParameterContext) GetRawValue() (any, error) {
-	return dpc.rc.GetColumnRawValue(dpc.column.Name)
+	return dpc.rc.GetRawColumnValue(dpc.column.Name)
 }
 
 func (dpc *DynamicParameterContext) GetColumnValue(name string) (any, error) {
 	return dpc.rc.GetColumnValue(name)
 }
 
-func (dpc *DynamicParameterContext) GetColumnRawValue(name string) (any, error) {
-	return dpc.rc.GetColumnRawValue(name)
+func (dpc *DynamicParameterContext) GetRawColumnValue(name string) (any, error) {
+	return dpc.rc.GetRawColumnValue(name)
 }
 
 func (dpc *DynamicParameterContext) EncodeValue(v any) (any, error) {

--- a/pkg/toolkit/expr.go
+++ b/pkg/toolkit/expr.go
@@ -157,7 +157,7 @@ func newRecordContext(driver *Driver) (*RecordContext, []expr.Option) {
 			fmt.Sprintf("__raw__%s", c.Name),
 			func(name string) func(params ...any) (any, error) {
 				return func(params ...any) (any, error) {
-					return rctx.GetColumnRawValue(name)
+					return rctx.GetRawColumnValue(name)
 				}
 			}(c.Name),
 		)

--- a/pkg/toolkit/template_record_context.go
+++ b/pkg/toolkit/template_record_context.go
@@ -61,7 +61,7 @@ func (rc *RecordContext) GetColumnValue(name string) (any, error) {
 	return v.Value, nil
 }
 
-func (rc *RecordContext) GetColumnRawValue(name string) (any, error) {
+func (rc *RecordContext) GetRawColumnValue(name string) (any, error) {
 	v, err := rc.record.GetRawColumnValueByName(name)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (rc *RecordContext) SetColumnValue(name string, v any) (bool, error) {
 	return true, nil
 }
 
-func (rc *RecordContext) SetColumnRawValue(name string, v any) (bool, error) {
+func (rc *RecordContext) SetRawColumnValue(name string, v any) (bool, error) {
 	var val *RawValue
 	switch vv := v.(type) {
 	case NullType:


### PR DESCRIPTION
Closes #238

* Renamed methods according to the documentation: `GetColumnRawValue` is now `GetRawColumnValue`, and `SetColumnRawValue` is now `SetRawColumnValue`.