### PR TITLE
Fix skipping unknown type when silent is true

### DIFF
--- a/pkg/toolkit/types.go
+++ b/pkg/toolkit/types.go
@@ -130,14 +130,16 @@ func TryRegisterCustomTypes(typeMap *pgtype.Map, types []*Type, silent bool) {
 		if t.Kind == 'd' {
 			if t.BaseType != 0 {
 				baseType, ok := typeMap.TypeForOID(uint32(t.BaseType))
-				if !ok && !silent {
-					log.Warn().
-						Str("Context", "CustomTypeRegistering").
-						Str("Schema", t.Schema).
-						Str("Name", t.Name).
-						Int("Oid", int(t.Oid)).
-						Str("Kind", fmt.Sprintf("%c", t.Kind)).
-						Msg("unable to register domain type")
+				if !ok {
+					if !silent {
+						log.Warn().
+							Str("Context", "CustomTypeRegistering").
+							Str("Schema", t.Schema).
+							Str("Name", t.Name).
+							Int("Oid", int(t.Oid)).
+							Str("Kind", fmt.Sprintf("%c", t.Kind)).
+							Msg("unable to register domain type")
+					}
 					continue
 				}
 				typeMap.RegisterType(&pgtype.Type{

--- a/pkg/toolkit/types.go
+++ b/pkg/toolkit/types.go
@@ -148,14 +148,16 @@ func TryRegisterCustomTypes(typeMap *pgtype.Map, types []*Type, silent bool) {
 					Codec: baseType.Codec,
 				})
 				arrayType, ok := typeMap.TypeForName(fmt.Sprintf("_%s", baseType.Name))
-				if !ok && !silent {
-					log.Warn().
-						Str("Context", "CustomTypeRegistering").
-						Str("Schema", t.Schema).
-						Str("Name", t.Name).
-						Int("Oid", int(t.Oid)).
-						Msg("cannot register array type for custom type")
-					continue
+				if !ok {
+					if !silent {
+						log.Warn().
+							Str("Context", "CustomTypeRegistering").
+							Str("Schema", t.Schema).
+							Str("Name", t.Name).
+							Int("Oid", int(t.Oid)).
+							Msg("cannot register array type for custom type")
+						continue
+					}
 				}
 				arrayTypeName := fmt.Sprintf("_%s", t.Name)
 				typeMap.RegisterType(&pgtype.Type{

--- a/pkg/toolkit/types.go
+++ b/pkg/toolkit/types.go
@@ -156,8 +156,9 @@ func TryRegisterCustomTypes(typeMap *pgtype.Map, types []*Type, silent bool) {
 							Str("Name", t.Name).
 							Int("Oid", int(t.Oid)).
 							Msg("cannot register array type for custom type")
-						continue
 					}
+					continue
+
 				}
 				arrayTypeName := fmt.Sprintf("_%s", t.Name)
 				typeMap.RegisterType(&pgtype.Type{


### PR DESCRIPTION
I was trying Greenmask on a more complex DB (musicbrainz) and it was crashing in this code. It seems that the issue is that when silent is true, the type is not actually skipped.

I opened a PR directly in case it's this simple, but if you'd rather have me open an issue instead, I'm happy to.