### PR TITLE
Support postgres:// schema connection URLs

### DIFF
--- a/internal/db/postgres/pgdump/pgdump.go
+++ b/internal/db/postgres/pgdump/pgdump.go
@@ -108,7 +108,7 @@ type Options struct {
 
 func (o *Options) GetPgDSN() (string, error) {
 	// URI or Standard format
-	if strings.HasPrefix(o.DbName, "postgresql://") || strings.Contains(o.DbName, "=") {
+	if strings.HasPrefix(o.DbName, "postgresql://") || strings.HasPrefix(o.DbName, "postgres://") || strings.Contains(o.DbName, "=") {
 		return o.DbName, nil
 	}
 

--- a/internal/db/postgres/pgrestore/pgrestore.go
+++ b/internal/db/postgres/pgrestore/pgrestore.go
@@ -138,7 +138,7 @@ func (o *Options) ToDataSectionSettings() *DataSectionSettings {
 }
 
 func (o *Options) GetPgDSN() (string, error) {
-	if strings.HasPrefix(o.DbName, "postgresql://") || strings.Contains(o.DbName, "=") {
+	if strings.HasPrefix(o.DbName, "postgresql://") || strings.HasPrefix(o.DbName, "postgres://") || strings.Contains(o.DbName, "=") {
 		return o.DbName, nil
 	}
 


### PR DESCRIPTION
Some tools spit out a connection URL with a `postgres://`, not `postgresql://`. It's useful to be able to support both, as `pg_dump` and `pg_restore` do.