### PR TITLE
fix: set lost ColumnContainer value for columns parameters

### DIFF
--- a/internal/db/postgres/transformers/random_company.go
+++ b/internal/db/postgres/transformers/random_company.go
@@ -25,7 +25,8 @@ var randomCompanyTransformerDefinition = utils.NewTransformerDefinition(
 	toolkit.MustNewParameterDefinition(
 		"columns",
 		"columns name",
-	).SetRequired(true),
+	).SetRequired(true).
+		SetIsColumnContainer(true),
 
 	engineParameterDefinition,
 )

--- a/internal/db/postgres/transformers/random_person.go
+++ b/internal/db/postgres/transformers/random_person.go
@@ -32,7 +32,8 @@ var randomPersonTransformerDefinition = utils.NewTransformerDefinition(
 	toolkit.MustNewParameterDefinition(
 		"columns",
 		"columns name",
-	).SetRequired(true),
+	).SetRequired(true).
+		SetIsColumnContainer(true),
 
 	toolkit.MustNewParameterDefinition(
 		"gender",

--- a/internal/db/postgres/transformers/template_record.go
+++ b/internal/db/postgres/transformers/template_record.go
@@ -48,7 +48,8 @@ var TemplateRecordTransformerDefinition = utils.NewTransformerDefinition(
 	toolkit.MustNewParameterDefinition(
 		"columns",
 		"columns that supposed to be affected by the template. The list of columns will be checked for constraint violation",
-	).SetRequired(false).
+	).SetIsColumnContainer(true).
+		SetRequired(false).
 		SetDefaultValue(toolkit.ParamsValue("[]")),
 )
 


### PR DESCRIPTION
`SetIsColumnContainer(true)` for strutural column-like parameters