### PR TITLE
fix #277: randomEmail hexEncodedBuffer contains null chars

### DIFF
--- a/internal/db/postgres/transformers/email.go
+++ b/internal/db/postgres/transformers/email.go
@@ -294,7 +294,7 @@ func (rit *EmailTransformer) generateEmail(data []byte) ([]byte, error) {
 		localPart = slices.Clone(rit.buf.Bytes())
 		rit.buf.Reset()
 	} else {
-		localPart = rit.hexEncodedRandomBytesBuf
+		localPart = rit.hexEncodedRandomBytesBuf[:2*len(data)]
 	}
 
 	if rit.domainTemplate != nil {


### PR DESCRIPTION
When the `EmailTransformer.hexEncodedRandomBytesBuf` is initialized, it is allocated as a 64 bytes buffer (`emailTransformerGeneratorSize`). The hex encoded buffer has to be at least twice the size of the content to encode. If it's larger, it crashes (this might also be an issue but a more obvious one). If it's smaller, it'll contain nulls.

To work around the issue, when not using a template for the local part of the email, we can just take twice the content size as buffer.