### PR TITLE
Use the correct form of `sha3.Sum224`.

### DIFF
--- a/internal/generators/hybrid_test.go
+++ b/internal/generators/hybrid_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSibHashHybrid(t *testing.T) {
-	expected := []byte{176, 20, 124, 157, 15, 119, 202, 213, 41, 32}
+	expected := []byte{0x8b, 0x16, 0xe4, 0xaa, 0x8d, 0x9, 0x2, 0xf1, 0x82, 0xcf}
 	requiredLength := 10
 	sp, err := NewSipHash([]byte("test"))
 	require.NoError(t, err)
@@ -18,5 +18,5 @@ func TestSibHashHybrid(t *testing.T) {
 		Bytes("Res", res).
 		Msg("")
 	require.NoError(t, err)
-	require.Equal(t, res, expected)
+	require.Equal(t, expected, res)
 }

--- a/internal/generators/siphash.go
+++ b/internal/generators/siphash.go
@@ -17,7 +17,8 @@ type SipHash struct {
 
 func NewSipHash(salt []byte) (Generator, error) {
 
-	salt = sha3.New224().Sum(salt)[:16]
+	sum224 := sha3.Sum224(salt)
+	salt = sum224[:16]
 
 	h := siphash.New(salt)
 


### PR DESCRIPTION
`sha3.New224().Sum(foo)` appends the SHA3-224 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk (different algo but same issue).