### PR TITLE
Fix: apply_for_references cannot be combined with when

### DIFF
--- a/pkg/toolkit/expr.go
+++ b/pkg/toolkit/expr.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	recordExprNamespace    = "record"
-	rawRecordExprNamespace = "raw_record"
+	TransformationConditionNamespaceRecord    = "record"
+	TransformationConditionNamespaceRawRecord = "raw_record"
 )
 
 // WhenCond - A condition that should be evaluated to determine if the record should be processed.
@@ -24,6 +24,11 @@ type WhenCond struct {
 	whenCond *vm.Program
 	when     string
 	env      map[string]any
+}
+
+// Condition returns the original when condition string
+func (wc *WhenCond) Condition() string {
+	return wc.when
 }
 
 // NewWhenCond - creates a new WhenCond object. It compiles when condition and returns the compiled program
@@ -204,7 +209,7 @@ func isRecordOp(node *ast.Node) bool {
 	if !ok {
 		return false
 	}
-	return owner.Value == recordExprNamespace || owner.Value == rawRecordExprNamespace
+	return owner.Value == TransformationConditionNamespaceRecord || owner.Value == TransformationConditionNamespaceRawRecord
 }
 
 // patchRecordOp patches the record access operation
@@ -225,14 +230,14 @@ func patchRecordOp(node *ast.Node) {
 	}
 	var newOp *ast.CallNode
 	switch owner.Value {
-	case recordExprNamespace:
+	case TransformationConditionNamespaceRecord:
 		newOp = &ast.CallNode{
 			Callee: &ast.IdentifierNode{
 				Value: fmt.Sprintf("__%s", attr.Value),
 			},
 		}
 
-	case rawRecordExprNamespace:
+	case TransformationConditionNamespaceRawRecord:
 		newOp = &ast.CallNode{
 			Callee: &ast.IdentifierNode{
 				Value: fmt.Sprintf("__raw__%s", attr.Value),


### PR DESCRIPTION
Changes:

This pull request introduces enhancements to the `config_builder` logic in the PostgreSQL context, focusing on improving the handling of transformer configurations, validation warnings, and inherited conditions. It also updates related tests and refactors the toolkit package for better readability and functionality.

### Enhancements to Transformer Configuration Logic:
* [`internal/db/postgres/context/config_builder.go`](diffhunk://#diff-2d42b3e7788461bad440f36970d9fb8f8afd44260f195ef4d17763c37064f418L213-R216): Updated the `getRefTables` and `buildRefsWithEndToEndDfs` functions to return validation warnings alongside results, ensuring better error handling during table configuration processing. [[1]](diffhunk://#diff-2d42b3e7788461bad440f36970d9fb8f8afd44260f195ef4d17763c37064f418L213-R216) [[2]](diffhunk://#diff-2d42b3e7788461bad440f36970d9fb8f8afd44260f195ef4d17763c37064f418L242-R290)
* [`internal/db/postgres/context/config_builder.go`](diffhunk://#diff-2d42b3e7788461bad440f36970d9fb8f8afd44260f195ef4d17763c37064f418R322-R365): Added a new function `validateDoesInheritedConditionHaveAllColumns` to check if inherited conditions reference valid columns in the target table, and integrated it into the `processReference` function. [[1]](diffhunk://#diff-2d42b3e7788461bad440f36970d9fb8f8afd44260f195ef4d17763c37064f418R322-R365) [[2]](diffhunk://#diff-2d42b3e7788461bad440f36970d9fb8f8afd44260f195ef4d17763c37064f418R390-R410)

### Test Coverage Improvements:
* [`internal/db/postgres/context/config_builder_test.go`](diffhunk://#diff-11d77eda06230b8c9ff71b952939c5f596f8a43f6a4a27c3c6d4260e0c354036R656-R863): Expanded test cases to validate the inheritance of `when` conditions, including scenarios with foreign key references, non-existent columns, and mixed namespaces.
* [`internal/db/postgres/context/config_builder_test.go`](diffhunk://#diff-11d77eda06230b8c9ff71b952939c5f596f8a43f6a4a27c3c6d4260e0c354036R656-R863): Added a dedicated test for `validateDoesInheritedConditionHaveAllColumns` to ensure its correctness across various edge cases.

### Refactoring for Consistency:
* [`pkg/toolkit/expr.go`](diffhunk://#diff-ab180ef11ff8703f066cd60ab7be4be9316496ee88d8f10ddb5e5226cc11fef8L17-R18): Refactored constants for transformation condition namespaces to improve clarity and renamed `recordExprNamespace` and `rawRecordExprNamespace` to `TransformationConditionNamespaceRecord` and `TransformationConditionNamespaceRawRecord`.
* [`pkg/toolkit/expr.go`](diffhunk://#diff-ab180ef11ff8703f066cd60ab7be4be9316496ee88d8f10ddb5e5226cc11fef8R29-R33): Added a `Condition` method to the `WhenCond` struct to retrieve the original condition string, enhancing usability.

### Additional Changes:
* [`internal/db/postgres/context/config_builder_test.go`](diffhunk://#diff-11d77eda06230b8c9ff71b952939c5f596f8a43f6a4a27c3c6d4260e0c354036R167-R206): Added new sample data and schema definitions in test setup to support extended test cases.

These updates collectively enhance the robustness of table configuration processing, ensure better validation of inherited conditions, and improve test coverage for future reliability.

Closes #296