### PR TITLE
Fix: set global salt from context

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,13 @@ jobs:
           path: coverage.out
           key: ${{ runner.os }}-coverage-${{ github.sha }}
 
+      - name: Build integration images
+        run: |
+          docker buildx build --load -t greenmask-test-dbs-filler:latest -f docker/integration/filldb/Dockerfile docker/integration/filldb
+          docker buildx build --load -t greenmask:latest -f docker/integration/tests/Dockerfile .
+
       - name: Run integration tests
         run: |
           docker compose -f docker-compose-integration.yml -p greenmask up \
-          --renew-anon-volumes --force-recreate --build --exit-code-from greenmask \
-          --abort-on-container-exit greenmask
+            --renew-anon-volumes --force-recreate \
+            --exit-code-from greenmask --abort-on-container-exit greenmask

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,11 @@ lint:
 
 up:
 	docker-compose up playground-dbs-filler
+
+integration:
+	docker buildx build --load -t greenmask-test-dbs-filler:latest -f docker/integration/filldb/Dockerfile docker/integration/filldb
+	docker buildx build --load -t greenmask-integration:latest -f docker/integration/tests/Dockerfile .
+	docker compose -f docker-compose-integration.yml -p greenmask up \
+                --renew-anon-volumes --force-recreate \
+                --exit-code-from greenmask --abort-on-container-exit greenmask
+

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -135,6 +135,7 @@ services:
 #    volumes:
 #      - "/tmp/greenmask_tests:/tmp/schema"
     build:
+      dockerfile: docker/integration/filldb/Dockerfile
       context: docker/integration/filldb
     depends_on:
       db-11:

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -127,6 +127,7 @@ services:
       retries: 3
 
   test-dbs-filler:
+    image: greenmask-test-dbs-filler:latest
     environment:
       PGPASSWORD: "example"
       FILE_DUMP: "demo-small-en.zip"
@@ -135,7 +136,6 @@ services:
 #    volumes:
 #      - "/tmp/greenmask_tests:/tmp/schema"
     build:
-      dockerfile: docker/integration/filldb/Dockerfile
       context: docker/integration/filldb
     depends_on:
       db-11:

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -154,6 +154,7 @@ services:
         condition: service_healthy
 
   greenmask:
+    image: greenmask-integration:latest
     volumes:
       - "/tmp"
     environment:

--- a/internal/db/postgres/transformers/utils.go
+++ b/internal/db/postgres/transformers/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/greenmaskio/greenmask/internal/db/postgres/transformers/utils"
 	"github.com/greenmaskio/greenmask/internal/generators"
+	commonutils "github.com/greenmaskio/greenmask/internal/utils"
 )
 
 const (
@@ -20,21 +21,10 @@ func getGenerateEngine(ctx context.Context, engineName string, size int) (genera
 	case RandomEngineParameterName:
 		return getRandomBytesGen(size)
 	case HashEngineParameterName:
-		salt, err := getSaltFromCtx(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("error getting salt from context: %w", err)
-		}
+		salt := commonutils.SaltFromCtx(ctx)
 		return generators.GetHashBytesGen(salt, size)
 	}
 	return nil, fmt.Errorf("unknown engine %s", engineName)
-}
-
-func getSaltFromCtx(ctx context.Context) (salt []byte, err error) {
-	saltAny := ctx.Value("salt")
-	if saltAny != nil {
-		salt = saltAny.([]byte)
-	}
-	return salt, nil
 }
 
 func getRandomBytesGen(size int) (generators.Generator, error) {

--- a/internal/db/postgres/transformers/utils_test.go
+++ b/internal/db/postgres/transformers/utils_test.go
@@ -1,0 +1,59 @@
+package transformers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/greenmaskio/greenmask/internal/utils"
+)
+
+func Test_getGenerateEngine(t *testing.T) {
+	t.Run("random", func(t *testing.T) {
+		ctx := context.Background()
+		g, err := getGenerateEngine(ctx, RandomEngineParameterName, 32)
+		require.NoError(t, err)
+		a, err := g.Generate([]byte("123"))
+		require.NoError(t, err)
+		b, err := g.Generate([]byte("123"))
+		require.NoError(t, err)
+		require.NotEqual(t, a, b)
+	})
+
+	t.Run("random with the same salt", func(t *testing.T) {
+		salt := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		ctx := utils.WithSalt(context.Background(), salt)
+
+		g1, err := getGenerateEngine(ctx, HashEngineParameterName, 32)
+		require.NoError(t, err)
+		a, err := g1.Generate([]byte("123"))
+		require.NoError(t, err)
+
+		g2, err := getGenerateEngine(ctx, HashEngineParameterName, 32)
+		require.NoError(t, err)
+		b, err := g2.Generate([]byte("123"))
+		require.NoError(t, err)
+
+		require.Equal(t, a, b)
+	})
+
+	t.Run("random with different salt", func(t *testing.T) {
+		salt1 := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		ctx1 := utils.WithSalt(context.Background(), salt1)
+
+		g1, err := getGenerateEngine(ctx1, HashEngineParameterName, 32)
+		require.NoError(t, err)
+		a, err := g1.Generate([]byte("123"))
+		require.NoError(t, err)
+
+		salt2 := []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+		ctx2 := utils.WithSalt(context.Background(), salt2)
+		g2, err := getGenerateEngine(ctx2, HashEngineParameterName, 32)
+		require.NoError(t, err)
+		b, err := g2.Generate([]byte("123"))
+		require.NoError(t, err)
+
+		require.NotEqual(t, a, b)
+	})
+}


### PR DESCRIPTION
Changes:
* Fixed global salt usage from context - now it correctly gets salt for generator. Covered by unit tests.
* Fixed github actions and docker compose for integration testings
* Added `make integration` target to run integration tests locally

Closes #317 