### PR TITLE
fix: RandomPerson hash generation

### DIFF
--- a/internal/db/postgres/transformers/random_person.go
+++ b/internal/db/postgres/transformers/random_person.go
@@ -212,7 +212,7 @@ func (nft *RandomNameTransformer) Transform(ctx context.Context, r *toolkit.Reco
 
 	// if we are in hash engine mode, we need to clear buffer before filling it with new data
 	if nft.engine == hashEngineMode {
-		clear(nft.originalData)
+		nft.originalData = nft.originalData[:0]
 		for _, c := range nft.columns {
 			rawVal, err := r.GetRawColumnValueByIdx(c.columnIdx)
 			if err != nil {


### PR DESCRIPTION
`clear(nft.originalData)` zeroes out the byte array, but doesnt change where we are appending the data, causing the byte slice to continually be prefixed with zeroed out values, resulting in data not hashing to the same value.

Closes https://github.com/GreenmaskIO/greenmask/issues/325