### PR TITLE
feature: Add description option to dump command and include in metadata

### DIFF
--- a/cmd/greenmask/cmd/dump/dump.go
+++ b/cmd/greenmask/cmd/dump/dump.go
@@ -84,6 +84,9 @@ func init() {
 	Cmd.Flags().IntP("lock-wait-timeout", "", -1, "fail after waiting TIMEOUT for a table lock")
 	Cmd.Flags().BoolP("no-sync", "", false, "do not wait for changes to be written safely to dis")
 
+	// Description options
+	Cmd.Flags().StringVarP(&Config.Dump.PgDumpOptions.Description, "description", "", "", "add a description for this dump")
+
 	// Options controlling the output content:
 	Cmd.Flags().BoolP("data-only", "a", false, "dump only the data, not the schema")
 	Cmd.Flags().BoolP("blobs", "b", true, "include large objects in dump")

--- a/cmd/greenmask/cmd/list_dumps/list_dumps.go
+++ b/cmd/greenmask/cmd/list_dumps/list_dumps.go
@@ -95,7 +95,7 @@ func listDumps() error {
 	})
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"id", "date", "database", "size", "compressed size", "duration", "transformed", "status"})
+	table.SetHeader([]string{"id", "date", "database", "size", "compressed size", "duration", "transformed", "status", "description"})
 	table.AppendBulk(data)
 	table.Render()
 	return nil
@@ -123,6 +123,14 @@ func renderListItem(ctx context.Context, st storages.Storager, data *[][]string)
 		}
 	}
 
+	description := ""
+	if metadata != nil {
+		description = metadata.Description
+		if len(description) > 60 {
+			description = description[:57] + "..."
+		}
+	}
+
 	*data = append(*data, []string{
 		dumpId,
 		creationDate,
@@ -132,6 +140,7 @@ func renderListItem(ctx context.Context, st storages.Storager, data *[][]string)
 		duration,
 		transformed,
 		status,
+		description,
 	})
 	return nil
 }

--- a/docs/commands/dump.md
+++ b/docs/commands/dump.md
@@ -19,6 +19,7 @@ Mostly it supports the same flags as the `pg_dump` utility, with some extra flag
   -C, --create                          include commands to create database in dump
   -a, --data-only                       dump only the data, not the schema
   -d, --dbname string                   database to dump (default "postgres")
+      --description string              add a description for this dump
       --disable-dollar-quoting          disable dollar quoting, use SQL standard quoting
       --enable-row-security             enable row security (dump only content user has access to)
   -E, --encoding string                 dump the data in encoding ENCODING

--- a/docs/commands/list-dumps.md
+++ b/docs/commands/list-dumps.md
@@ -15,6 +15,8 @@ The `list-dumps` command provides a list of all dumps stored in the storage. The
     * `failed` — the dump creation process failed
     * `unknown or failed` — the deprecated status of the dump that is used for failed dumps or dumps in progress for 
        version v0.1.14 and earlier
+* `DESCRIPTION` — an optional user-provided note about the dump
+
 
 Example of `list-dumps` output:
 ![list_dumps_screen.png](../assets/list_dumps_screen.png)

--- a/internal/db/postgres/cmd/dump.go
+++ b/internal/db/postgres/cmd/dump.go
@@ -458,9 +458,13 @@ func (d *Dump) mergeAndWriteToc(ctx context.Context) error {
 
 func (d *Dump) writeMetaData(ctx context.Context, startedAt, completedAt time.Time) error {
 	cycles := d.context.Graph.GetCycledTables()
+	description := ""
+	if d.config != nil {
+		description = d.config.Dump.PgDumpOptions.Description
+	}
 	metadata, err := storageDto.NewMetadata(
 		d.resultToc, d.tocFileSize, startedAt, completedAt, d.config.Dump.Transformation, d.dumpedObjectSizes,
-		d.context.DatabaseSchema, d.dumpDependenciesGraph, d.sortedTablesDumpIds, cycles, d.tableOidToDumpId,
+		d.context.DatabaseSchema, d.dumpDependenciesGraph, d.sortedTablesDumpIds, cycles, d.tableOidToDumpId, description,
 	)
 	if err != nil {
 		return fmt.Errorf("unable build metadata: %w", err)

--- a/internal/db/postgres/pgdump/pgdump.go
+++ b/internal/db/postgres/pgdump/pgdump.go
@@ -54,6 +54,7 @@ type Options struct {
 	Compression     int    `mapstructure:"compress"`
 	LockWaitTimeout int    `mapstructure:"lock-wait-timeout"`
 	NoSync          bool   `mapstructure:"no-sync"`
+	Description     string `mapstructure:"description"`
 
 	// Options controlling the output content
 	DataOnly                   bool     `mapstructure:"data-only"`

--- a/internal/db/postgres/storage/metadata_json.go
+++ b/internal/db/postgres/storage/metadata_json.go
@@ -64,6 +64,7 @@ type Metadata struct {
 	CompletedAt       time.Time              `yaml:"completedAt" json:"completedAt"`
 	OriginalSize      int64                  `yaml:"originalSize" json:"originalSize"`
 	CompressedSize    int64                  `yaml:"compressedSize" json:"compressedSize"`
+	Description       string                 `yaml:"description" json:"description"`
 	Transformers      []*domains.Table       `yaml:"transformers" json:"transformers"`
 	DatabaseSchema    toolkit.DatabaseSchema `yaml:"database_schema" json:"database_schema"`
 	Header            Header                 `yaml:"header" json:"header"`
@@ -80,7 +81,7 @@ func NewMetadata(
 	completedAt time.Time, transformers []*domains.Table,
 	stats map[int32]ObjectSizeStat, databaseSchema []*toolkit.Table,
 	dependenciesGraph map[int32][]int32, dumpIdsOrder []int32,
-	cycles [][]string, tableOidToDumpId map[toolkit.Oid]int32,
+	cycles [][]string, tableOidToDumpId map[toolkit.Oid]int32, description string,
 ) (*Metadata, error) {
 
 	var format string
@@ -171,6 +172,7 @@ func NewMetadata(
 		CompressedSize:    totalCompressedSize,
 		StartedAt:         startedAt,
 		CompletedAt:       completedAt,
+		Description:       description,
 		Transformers:      transformers,
 		DatabaseSchema:    databaseSchema,
 		DependenciesGraph: dependenciesGraph,


### PR DESCRIPTION
**Problem**
Dump IDs are not human-friendly, and over time it becomes hard to remember the purpose of each dump.

**Proposed Solution**
Add a `--description` flag to the dump command, store it in metadata, and display it in `list_dumps` for better context.