### PR TITLE
fix: restore ACL entries when using --restore-in-order

### DIFF
--- a/internal/db/postgres/cmd/restore_test.go
+++ b/internal/db/postgres/cmd/restore_test.go
@@ -138,6 +138,133 @@ func TestRestore_sortTocEntriesInTopoOrder_PreserveOriginalBehavior(t *testing.T
 	assert.Equal(t, toc.TableDataDesc, *result[1].Desc)
 }
 
+func TestRestore_sortTocEntriesInTopoOrder_BugFix_IncludesACLs(t *testing.T) {
+	// Setup: Tables and ACL entries
+	metadata := &storage.Metadata{
+		DumpIdsOrder: []int32{100, 101}, // Only tables are in topological order
+		DumpIdsToTableOid: map[int32]toolkit.Oid{
+			100: 1000,
+			101: 1001,
+		},
+		DatabaseSchema: toolkit.DatabaseSchema{
+			{Oid: 1000, Schema: "public", Name: "users"},
+			{Oid: 1001, Schema: "public", Name: "posts"},
+		},
+		Cycles: [][]string{},
+	}
+
+	// Data section entries (tables)
+	dataEntries := []*toc.Entry{
+		{
+			DumpId:  100,
+			Section: toc.SectionData,
+			Desc:    strPtr(toc.TableDataDesc),
+			Tag:     strPtr("users"),
+		},
+		{
+			DumpId:  101,
+			Section: toc.SectionData,
+			Desc:    strPtr(toc.TableDataDesc),
+			Tag:     strPtr("posts"),
+		},
+	}
+
+	// ACL entries that would normally be in the full TOC
+	aclEntries := []*toc.Entry{
+		{
+			DumpId:  300,
+			Section: toc.SectionNone,
+			Desc:    strPtr(toc.AclDesc),
+			Tag:     strPtr("TABLE users"),
+		},
+		{
+			DumpId:  301,
+			Section: toc.SectionNone,
+			Desc:    strPtr(toc.AclDesc),
+			Tag:     strPtr("TABLE posts"),
+		},
+		{
+			DumpId:  302,
+			Section: toc.SectionNone,
+			Desc:    strPtr(toc.AclDesc),
+			Tag:     strPtr("SCHEMA public"),
+		},
+	}
+
+	// Create a TOC object with all entries
+	tocObj := &toc.Toc{
+		Entries: append(dataEntries, aclEntries...),
+	}
+
+	r := &Restore{
+		metadata: metadata,
+		tocObj:   tocObj,
+	}
+
+	// sortTocEntriesInTopoOrder should include ACL entries when tocObj is present
+	result := r.sortTocEntriesInTopoOrder(dataEntries)
+
+	require.Len(t, result, 5, "Should include both tables and ACLs")
+
+	// Verify: Order should be tables first (topologically sorted), then ACLs
+	assert.Equal(t, int32(100), result[0].DumpId, "First should be users table")
+	assert.Equal(t, int32(101), result[1].DumpId, "Second should be posts table")
+
+	// ACL entries should come after data entries
+	aclDumpIds := []int32{result[2].DumpId, result[3].DumpId, result[4].DumpId}
+	assert.Contains(t, aclDumpIds, int32(300), "Should include users ACL")
+	assert.Contains(t, aclDumpIds, int32(301), "Should include posts ACL")
+	assert.Contains(t, aclDumpIds, int32(302), "Should include schema ACL")
+
+	// Verify: Entry types are correct
+	assert.Equal(t, toc.TableDataDesc, *result[0].Desc)
+	assert.Equal(t, toc.TableDataDesc, *result[1].Desc)
+	assert.Equal(t, toc.AclDesc, *result[2].Desc)
+	assert.Equal(t, toc.AclDesc, *result[3].Desc)
+	assert.Equal(t, toc.AclDesc, *result[4].Desc)
+
+	// Verify: No duplicates
+	seen := make(map[int32]bool)
+	for _, entry := range result {
+		assert.False(t, seen[entry.DumpId], "No duplicate DumpIds should exist")
+		seen[entry.DumpId] = true
+	}
+}
+
+func TestRestore_sortTocEntriesInTopoOrder_ACLs_WithoutTocObj(t *testing.T) {
+	// Setup: When tocObj is nil (as in some test scenarios), ACLs should not be added
+	metadata := &storage.Metadata{
+		DumpIdsOrder: []int32{100},
+		DumpIdsToTableOid: map[int32]toolkit.Oid{
+			100: 1000,
+		},
+		DatabaseSchema: toolkit.DatabaseSchema{
+			{Oid: 1000, Schema: "public", Name: "users"},
+		},
+		Cycles: [][]string{},
+	}
+
+	dataEntries := []*toc.Entry{
+		{
+			DumpId:  100,
+			Section: toc.SectionData,
+			Desc:    strPtr(toc.TableDataDesc),
+			Tag:     strPtr("users"),
+		},
+	}
+
+	r := &Restore{
+		metadata: metadata,
+		tocObj:   nil, // No TOC object
+	}
+
+	result := r.sortTocEntriesInTopoOrder(dataEntries)
+
+	// Should not crash and should only return data entries
+	require.Len(t, result, 1, "Should only include the table when tocObj is nil")
+	assert.Equal(t, int32(100), result[0].DumpId, "Should be users table")
+}
+
 // Helper functions
 func strPtr(s string) *string {
 	return &s

--- a/internal/db/postgres/restorers/acl.go
+++ b/internal/db/postgres/restorers/acl.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restorers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/greenmaskio/greenmask/internal/db/postgres/toc"
+	"github.com/greenmaskio/greenmask/internal/db/postgres/utils"
+)
+
+type AclRestorer struct {
+	Entry *toc.Entry
+}
+
+func NewAclRestorer(entry *toc.Entry) *AclRestorer {
+	return &AclRestorer{
+		Entry: entry,
+	}
+}
+
+func (ar *AclRestorer) GetEntry() *toc.Entry {
+	return ar.Entry
+}
+
+func (ar *AclRestorer) Execute(ctx context.Context, conn utils.PGConnector) error {
+	err := conn.WithTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		if ar.Entry.Defn == nil {
+			return fmt.Errorf("received nil pointer instead of ACL definition")
+		}
+		_, err := tx.Exec(ctx, *ar.Entry.Defn)
+		if err != nil {
+			return fmt.Errorf("unable to apply ACL: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("cannot commit transaction (restoring %s): %w", ar.DebugInfo(), err)
+	}
+	return nil
+}
+
+func (ar *AclRestorer) DebugInfo() string {
+	if ar.Entry.Tag != nil {
+		return fmt.Sprintf("ACL %s", *ar.Entry.Tag)
+	}
+	return "ACL"
+}

--- a/internal/db/postgres/restorers/acl_test.go
+++ b/internal/db/postgres/restorers/acl_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restorers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/greenmaskio/greenmask/internal/db/postgres/toc"
+)
+
+func TestNewAclRestorer(t *testing.T) {
+	entry := &toc.Entry{
+		DumpId: 123,
+		Tag:    strPtr("TABLE users"),
+		Desc:   strPtr(toc.AclDesc),
+		Defn:   strPtr("GRANT SELECT ON TABLE public.users TO readonly;"),
+	}
+
+	restorer := NewAclRestorer(entry)
+
+	require.NotNil(t, restorer)
+	assert.Equal(t, entry, restorer.Entry)
+}
+
+func TestAclRestorer_GetEntry(t *testing.T) {
+	entry := &toc.Entry{
+		DumpId: 123,
+		Tag:    strPtr("TABLE users"),
+		Desc:   strPtr(toc.AclDesc),
+		Defn:   strPtr("GRANT SELECT ON TABLE public.users TO readonly;"),
+	}
+
+	restorer := NewAclRestorer(entry)
+	assert.Equal(t, entry, restorer.GetEntry())
+}
+
+func TestAclRestorer_DebugInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    *toc.Entry
+		expected string
+	}{
+		{
+			name: "with tag",
+			entry: &toc.Entry{
+				Tag: strPtr("TABLE users"),
+			},
+			expected: "ACL TABLE users",
+		},
+		{
+			name:     "without tag",
+			entry:    &toc.Entry{},
+			expected: "ACL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restorer := NewAclRestorer(tt.entry)
+			assert.Equal(t, tt.expected, restorer.DebugInfo())
+		})
+	}
+}
+
+// Helper function
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
@wwoytenko Sorry for the confusion. I know what happened. I messed up a branch and that's why we had two times the same PR. Here's the missing one.

ACL (Access Control List) entries were not being restored when using the --restore-in-order flag because they have Section=SectionNone and were filtered out by getDataSectionTocEntries().

Changes:
- Modified sortTocEntriesInTopoOrder to include ACL entries from the full TOC when restore-in-order is used
- Added new AclRestorer following the same pattern as SequenceRestorer
- Added nil check for tocObj to prevent panics in tests
- Added comprehensive tests for ACL restoration
- ACL entries are now restored after data entries to ensure referenced objects exist