### PR TITLE
feat: add postcode masking type

### DIFF
--- a/docs/built_in_transformers/advanced_transformers/custom_functions/core_functions.md
+++ b/docs/built_in_transformers/advanced_transformers/custom_functions/core_functions.md
@@ -61,6 +61,7 @@ on [ggwhite/go-masker](https://github.com/ggwhite/go-masker).
     | `id`          | Masks last 4 digits of an ID                                                                                     | `A123456789`                                       | `A12345****`                            |
     | `credit_card` | Masks 6 digits starting from the 7th digit                                                                       | `1234567890123456`                                 | `123456******3456`                      |
     | `url`         | Masks the password part of the URL (if applicable)                                                               | `http://admin:mysecretpassword@localhost:1234/uri` | `http://admin:xxxxx@localhost:1234/uri` |
+    | `postcode`    | Keeps first 2 characters, masks the rest                                                                         | `SW1A 1AA`                                         | `SW******`                              |
 
 === "Signature"
 

--- a/docs/built_in_transformers/standard_transformers/masking.md
+++ b/docs/built_in_transformers/standard_transformers/masking.md
@@ -5,7 +5,7 @@ Mask a value using one of the masking rules depending on your domain. `NULL` val
 | Name   | Description                                                                                                     | Default   | Required | Supported DB types                  |
 |--------|-----------------------------------------------------------------------------------------------------------------|-----------|----------|-------------------------------------|
 | column | The name of the column to be affected                                                                           |           | Yes      | text, varchar, char, bpchar, citext |
-| type   | Data type of attribute (`default`, `password`, `name`, `addr`, `email`, `mobile`, `tel`, `id`, `credit`, `url`) | `default` | No       | -                                   |
+| type   | Data type of attribute (`default`, `password`, `name`, `addr`, `email`, `mobile`, `tel`, `id`, `credit`, `url`, `postcode`) | `default` | No       | -                                   |
 
 ## Description
 
@@ -25,6 +25,7 @@ supports the following masking rules:
 |     id      | Masks last 4 digits of ID number, e. g. input: `A123456789` output: `A12345****`                                                                                     |
 | credit_cart | Masks 6 digits starting from the 7th digit, e. g. input `1234567890123456` output `123456******3456`                                                                 |
 |     url     | Masks the password part of the URL, if applicable, e. g. `http://admin:mysecretpassword@localhost:1234/uri` output: `http://admin:xxxxx@localhost:1234/uri`          |
+|  postcode   | Keeps first 2 characters, masks the rest, e. g. input: `SW1A 1AA` output: `SW******`                                                                                 |
 
 ## Example: Masking employee national ID number
 

--- a/internal/db/postgres/transformers/masking.go
+++ b/internal/db/postgres/transformers/masking.go
@@ -36,6 +36,7 @@ const (
 	MID         string = "id"
 	MCreditCard string = "credit_card"
 	MURL        string = "url"
+	MPostcode   string = "postcode"
 	MDefault    string = "default"
 )
 
@@ -62,7 +63,7 @@ var MaskingTransformerDefinition = utils.NewTransformerDefinition(
 
 	toolkit.MustNewParameterDefinition(
 		"type",
-		"logical type of attribute (default, password, name, addr, email, mobile, tel, id, credit_card, url)",
+		"logical type of attribute (default, password, name, addr, email, mobile, tel, id, credit_card, url, postcode)",
 	).SetRawValueValidator(maskerTypeValidator).
 		SetDefaultValue(toolkit.ParamsValue(MDefault)),
 )
@@ -121,6 +122,8 @@ func NewMaskingTransformer(ctx context.Context, driver *toolkit.Driver, paramete
 		mf = m.CreditCard
 	case MURL:
 		mf = m.URL
+	case MPostcode:
+		mf = postcodeMasker
 	case MDefault:
 		mf = defaultMasker
 	default:
@@ -169,10 +172,17 @@ func defaultMasker(v string) string {
 	return strings.Repeat("*", len(v))
 }
 
+func postcodeMasker(v string) string {
+	if len(v) <= 2 {
+		return v
+	}
+	return v[:2] + strings.Repeat("*", len(v)-2)
+}
+
 func maskerTypeValidator(p *toolkit.ParameterDefinition, v toolkit.ParamsValue) (toolkit.ValidationWarnings, error) {
 	typeName := string(v)
 
-	types := []string{MDefault, MPassword, MName, MAddress, MEmail, MMobile, MTelephone, MID, MCreditCard, MURL}
+	types := []string{MDefault, MPassword, MName, MAddress, MEmail, MMobile, MTelephone, MID, MCreditCard, MURL, MPostcode}
 	if !slices.Contains(types, typeName) {
 		return toolkit.ValidationWarnings{
 			toolkit.NewValidationWarning().

--- a/internal/db/postgres/transformers/masking_test.go
+++ b/internal/db/postgres/transformers/masking_test.go
@@ -68,6 +68,15 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 			originalValue: "1234567890",
 			expectedValue: toolkit.NewValue("**********", false),
 		},
+		{
+			name: MPostcode,
+			params: map[string]toolkit.ParamsValue{
+				"column": toolkit.ParamsValue("data"),
+				"type":   toolkit.ParamsValue(MPostcode),
+			},
+			originalValue: "SW1A 1AA",
+			expectedValue: toolkit.NewValue("SW******", false),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
My apologies, this is my first time contributing here, so I'm not sure what the conventions are, but in our code base we wanted to use a custom masker for postcodes, so I thought I would just contribute this back. It's very simple. Nothing special here, just not sure if this is useful for others.

Added a new 'postcode' masking type that preserves only the first 2 characters. This masking option helps us when working with geographic data where the area code (first part) is needed for analytics while protecting specific location details.

Implemented with basic test and updated documentation with the help of an LLM (Claude).