### PR TITLE
fix: Fix TOC entry duplication when merging schema and data sections

### DIFF
--- a/internal/db/postgres/cmd/dump.go
+++ b/internal/db/postgres/cmd/dump.go
@@ -552,8 +552,8 @@ func (d *Dump) MergeTocEntries(schemaEntries []*toc.Entry, dataEntries []*toc.En
 	// TODO: Assign dependencies and sort entries in the same order
 	res := make([]*toc.Entry, 0, len(schemaEntries)+len(dataEntries))
 
-	preDataEnd := 0
-	postDataStart := len(schemaEntries) - 1
+	preDataEnd := -1
+	postDataStart := -1
 
 	// Find predata last index and postdata first index
 	for idx, item := range schemaEntries {
@@ -566,13 +566,18 @@ func (d *Dump) MergeTocEntries(schemaEntries []*toc.Entry, dataEntries []*toc.En
 		}
 	}
 
-	res = append(res, schemaEntries[:preDataEnd+1]...)
+	if preDataEnd >= 0 {
+		res = append(res, schemaEntries[:preDataEnd+1]...)
+	}
+
 	if d.blobs != nil {
 		blobsDDLEntries := d.blobs.GetAllDDLs()
 		res = append(res, blobsDDLEntries...)
 	}
 	res = append(res, dataEntries...)
-	res = append(res, schemaEntries[postDataStart:]...)
+	if postDataStart != -1 {
+		res = append(res, schemaEntries[postDataStart:]...)
+	}
 
 	return res, nil
 }

--- a/internal/db/postgres/cmd/dump_test.go
+++ b/internal/db/postgres/cmd/dump_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/greenmaskio/greenmask/internal/db/postgres/toc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDump_MergeTocEntries(t *testing.T) {
+	// helper to build minimal TOC entries
+	e := func(id int32, section int32) *toc.Entry {
+		return &toc.Entry{
+			DumpId:  id,
+			Section: section,
+		}
+	}
+
+	dumpIds := func(entries []*toc.Entry) []int32 {
+		out := make([]int32, 0, len(entries))
+		for _, e := range entries {
+			out = append(out, e.DumpId)
+		}
+		return out
+	}
+
+	t.Run("no data entries returns schema as-is", func(t *testing.T) {
+		d := &Dump{}
+
+		schema := []*toc.Entry{
+			e(1, toc.SectionPreData),
+			e(2, toc.SectionPreData),
+			e(3, toc.SectionPostData),
+		}
+
+		res, err := d.MergeTocEntries(schema, nil)
+		require.NoError(t, err)
+		assert.Equal(t, dumpIds(schema), dumpIds(res))
+	})
+
+	t.Run("all sections exist predata data postdata", func(t *testing.T) {
+		d := &Dump{}
+
+		schema := []*toc.Entry{
+			e(1, toc.SectionPreData),
+			e(2, toc.SectionPreData),
+			e(3, toc.SectionPostData),
+			e(4, toc.SectionPostData),
+		}
+
+		data := []*toc.Entry{
+			e(10, toc.SectionData),
+			e(11, toc.SectionData),
+		}
+
+		res, err := d.MergeTocEntries(schema, data)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			[]int32{1, 2, 10, 11, 3, 4},
+			dumpIds(res),
+		)
+	})
+
+	t.Run("no postdata section", func(t *testing.T) {
+		d := &Dump{}
+
+		schema := []*toc.Entry{
+			e(1, toc.SectionPreData),
+			e(2, toc.SectionPreData),
+			e(3, toc.SectionPreData),
+		}
+
+		data := []*toc.Entry{
+			e(10, toc.SectionData),
+		}
+
+		res, err := d.MergeTocEntries(schema, data)
+		require.NoError(t, err)
+
+		// PreData -> Data, no duplication
+		assert.Equal(
+			t,
+			[]int32{1, 2, 3, 10},
+			dumpIds(res),
+		)
+	})
+
+	t.Run("no predata section", func(t *testing.T) {
+		d := &Dump{}
+
+		schema := []*toc.Entry{
+			e(3, toc.SectionPostData),
+			e(4, toc.SectionPostData),
+		}
+
+		data := []*toc.Entry{
+			e(10, toc.SectionData),
+		}
+
+		res, err := d.MergeTocEntries(schema, data)
+		require.NoError(t, err)
+
+		// Data -> PostData
+		assert.Equal(
+			t,
+			[]int32{10, 3, 4},
+			dumpIds(res),
+		)
+	})
+
+	t.Run("schema without sections only data returned", func(t *testing.T) {
+		d := &Dump{}
+
+		schema := []*toc.Entry{
+			e(1, toc.SectionNone),
+			e(2, toc.SectionNone),
+		}
+
+		data := []*toc.Entry{
+			e(10, toc.SectionData),
+		}
+
+		res, err := d.MergeTocEntries(schema, data)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			[]int32{10},
+			dumpIds(res),
+		)
+	})
+
+	t.Run("regression no duplicated schema entries", func(t *testing.T) {
+		d := &Dump{}
+
+		schema := []*toc.Entry{
+			e(1, toc.SectionPreData),
+			e(2, toc.SectionPreData),
+		}
+
+		data := []*toc.Entry{
+			e(10, toc.SectionData),
+		}
+
+		res, err := d.MergeTocEntries(schema, data)
+		require.NoError(t, err)
+
+		ids := dumpIds(res)
+
+		assert.Equal(t, []int32{1, 2, 10}, ids)
+		assert.Len(t, ids, 3)
+	})
+}


### PR DESCRIPTION
Fix TOC entry duplication when merging schema and data sections