### PR TITLE
feat: Pg18 support

### DIFF
--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -21,6 +21,21 @@ services:
       timeout: 5s
       retries: 2
 
+  db-18:
+    volumes:
+      - "/var/lib/postgresql/18/data"
+    image: postgres:18
+    ports:
+      - "54318:5432"
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: example
+    healthcheck:
+      test: [ "CMD", "psql", "-U", "postgres" ]
+      interval: 5s
+      timeout: 1s
+      retries: 3
+
   db-17:
     volumes:
       - "/var/lib/postgresql/data"
@@ -96,52 +111,18 @@ services:
       timeout: 1s
       retries: 3
 
-  db-12:
-    volumes:
-      - "/var/lib/postgresql/data"
-    image: postgres:12
-    ports:
-      - "54312:5432"
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: example
-    healthcheck:
-      test: [ "CMD", "psql", "-U", "postgres" ]
-      interval: 5s
-      timeout: 1s
-      retries: 3
-
-  db-11:
-    volumes:
-      - "/var/lib/postgresql/data"
-    image: postgres:11
-    ports:
-      - "54311:5432"
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: example
-    healthcheck:
-      test: [ "CMD", "psql", "-U", "postgres" ]
-      interval: 5s
-      timeout: 1s
-      retries: 3
-
   test-dbs-filler:
     image: greenmask-test-dbs-filler:latest
     environment:
       PGPASSWORD: "example"
       FILE_DUMP: "demo-small-en.zip"
       TMP_DIR: "/tmp/schema"
-      PG_VERSIONS_CHECK: "11,12,13,14,15,16,17"
+      PG_VERSIONS_CHECK: "13,14,15,16,17,18"
 #    volumes:
 #      - "/tmp/greenmask_tests:/tmp/schema"
     build:
       context: docker/integration/filldb
     depends_on:
-      db-11:
-        condition: service_healthy
-      db-12:
-        condition: service_healthy
       db-13:
         condition: service_healthy
       db-14:
@@ -152,13 +133,15 @@ services:
         condition: service_healthy
       db-17:
         condition: service_healthy
+      db-18:
+        condition: service_healthy
 
   greenmask:
     image: greenmask-integration:latest
     volumes:
       - "/tmp"
     environment:
-      PG_VERSIONS_CHECK: "11,12,13,14,15,16,17"
+      PG_VERSIONS_CHECK: "13,14,15,16,17,18"
 
       PG_USER: postgres
       PG_PASSWORD: example

--- a/docker/greenmask/Dockerfile
+++ b/docker/greenmask/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
+        postgresql-client-18 \
         postgresql-client-17 \
         postgresql-client-16 \
         postgresql-client-15 \

--- a/docker/integration/tests/Dockerfile
+++ b/docker/integration/tests/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 lsb-release make \
     && echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -sc)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update && apt-get install --yes --no-install-recommends --no-install-suggests  \
+        postgresql-18 \
         postgresql-17 \
         postgresql-16 \
         postgresql-15 \

--- a/internal/db/postgres/context/tables_introspection.go
+++ b/internal/db/postgres/context/tables_introspection.go
@@ -19,10 +19,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/greenmaskio/greenmask/pkg/toolkit"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-
-	"github.com/greenmaskio/greenmask/pkg/toolkit"
+	"github.com/rs/zerolog/log"
 )
 
 var typeSizes = map[string]int{
@@ -165,14 +165,14 @@ func getTableConstraints(ctx context.Context, tx pgx.Tx, tableOid toolkit.Oid, v
 				Columns:    constraintColumns,
 				Definition: constraintDefinition,
 			}
-		case 'x':
-			c = &toolkit.Exclusion{
-				Schema:     constraintSchema,
-				Name:       constraintName,
-				Oid:        constraintOid,
-				Columns:    constraintColumns,
-				Definition: constraintDefinition,
-			}
+		case 'n':
+			// Ignore not null constraint as it's introspected in table definition query.
+			// Before pg18 it was only for domain types, since 18 all null constraints
+			// can be found in pg_constraint table.
+			log.Debug().
+				Str("ConstraintType", string(constraintType)).
+				Msg("ignoring table constraint")
+			continue
 		default:
 			return nil, fmt.Errorf("unknown constraint type %c", constraintType)
 		}


### PR DESCRIPTION
Added pg18 into integration tests and fixed constraint introspection for pg18. Removed versions 11 and 12 from the integration testing. But we kept 11 and 12 versions it in the Greenmask image in docker hub repo

Closes #341 