### PR TITLE
fix: fixed deterministic order in pk/fk introspection query.

### DIFF
--- a/internal/db/postgres/context/queries.go
+++ b/internal/db/postgres/context/queries.go
@@ -257,7 +257,7 @@ var (
 	`
 
 	PrimaryKeyColumnsQuery = `
-		select array_agg(DISTINCT a.attname) AS pk_columns
+		select array_agg(a.attname ORDER BY array_position(pcp.conkey, a.attnum)) AS pk_columns
 		from pg_catalog.pg_constraint pcp
 			JOIN pg_catalog.pg_attribute a ON a.attrelid = pcp.conrelid AND a.attnum = ANY (pcp.conkey) AND pcp.contype = 'p'
 		WHERE pcp.conrelid = $1;

--- a/internal/db/postgres/subset/graph.go
+++ b/internal/db/postgres/subset/graph.go
@@ -25,7 +25,7 @@ var (
 	foreignKeyColumnsQuery = `
 		SELECT n.nspname                as             fk_table_schema,
 			   fk_ref_table.relname     as             fk_table_name,
-			   array_agg(curr_table_attrs.attname)     curr_table_columns,
+			   array_agg(curr_table_attrs.attname ORDER BY array_position(curr_table_con.conkey, curr_table_attrs.attnum))     curr_table_columns,
 			   bool_or(NOT attnotnull)  as 		       is_nullable
 		FROM pg_catalog.pg_constraint curr_table_con
 				 join pg_catalog.pg_class fk_ref_table on curr_table_con.confrelid = fk_ref_table.oid


### PR DESCRIPTION
Closes #397

The issue was caused by non-deterministic ordering of columns in multi-column primary and foreign keys. When fetching primary key columns and foreign key columns from the PostgreSQL catalog, the queries used array_agg without an ORDER BY clause, which resulted in column names being returned in an arbitrary order (often by attnum or randomly depending on the query execution plan).

Since the subset system relies on matching these columns by their index in the returned slices, any mismatch in order led to incorrect JOIN clauses, such as: ON t.per_id = c.crc_number AND t.crc_number = c.per_id instead of the correct ON t.per_id = c.per_id AND t.crc_number = c.crc_numbe