### PR TITLE
fix: escape double-quote characters in SQL identifier quoting

### DIFF
--- a/internal/db/postgres/entries/sequence.go
+++ b/internal/db/postgres/entries/sequence.go
@@ -43,7 +43,7 @@ func (s *Sequence) Entry() (*toc.Entry, error) {
 	if !s.IsCalled {
 		isCalled = "false"
 	}
-	statement := fmt.Sprintf(`SELECT pg_catalog.setval('"%s"."%s"', %d, %s);`, s.Schema, s.Name, s.LastValue, isCalled)
+	statement := fmt.Sprintf(`SELECT pg_catalog.setval('"%s"."%s"', %d, %s);`, escapeIdent(s.Schema), escapeIdent(s.Name), s.LastValue, isCalled)
 
 	name := fmt.Sprintf(`"%s"`, s.Name)
 	schema := fmt.Sprintf(`"%s"`, s.Schema)


### PR DESCRIPTION
## Problem

When a table (or sequence) name contains literal double-quote characters — e.g. created with:

```sql
CREATE TABLE """escalade_schema_migrations""" ();
```

the actual name stored in `pg_catalog` is `"escalade_schema_migrations"` (with embedded `"` chars).

When greenmask built the `COPY` statement using `fmt.Sprintf`:

```go
fmt.Sprintf("COPY \"%s\".\"%s\" TO STDOUT", t.Schema, t.Name)
```

it produced invalid SQL:

```sql
COPY "public".""escalade_schema_migrations"" TO STDOUT
```

PostgreSQL treats `""` immediately after the opening quote as a zero-length identifier and returns:

```
zero-length delimited identifier at or near """"  code=42601
```

## Fix

Added `escapeIdent` helper that doubles any `"` characters inside an identifier name before embedding it in a double-quoted SQL context (standard SQL escaping rule).

Applied in:
- `GetCopyFromStatement()` — COPY query sent during dump
- `Entry()` COPY FROM statement — stored in TOC for restore
- `Entry()` column name quoting
- `Sequence.Entry()` `setval` statement