### PR TITLE
fix(subset): deduplicate CTE names when a table is reachable via multiple FK paths

### DIFF
--- a/internal/db/postgres/subset/cte.go
+++ b/internal/db/postgres/subset/cte.go
@@ -9,17 +9,23 @@ import (
 )
 
 type cteQuery struct {
-	items []*cteItem
-	c     *Component
+	items      []*cteItem
+	addedNames map[string]struct{}
+	c          *Component
 }
 
 func newCteQuery(c *Component) *cteQuery {
 	return &cteQuery{
-		c: c,
+		c:          c,
+		addedNames: make(map[string]struct{}),
 	}
 }
 
 func (c *cteQuery) addItem(name, query string) {
+	if _, exists := c.addedNames[name]; exists {
+		return
+	}
+	c.addedNames[name] = struct{}{}
 	c.items = append(c.items, &cteItem{
 		name:  name,
 		query: query,


### PR DESCRIPTION
## Problem

When the FK graph contains a diamond pattern — a shared dependency reachable from the subset root via two or more distinct FK paths — `cteQuery.addItem` was called multiple times with the same CTE name. This produced a `WITH` clause with duplicate names, which PostgreSQL rejects with error **42712**:

```
WITH query name "public__<schema>__<table>__ids" specified more than once
```

### Reproduction

Any schema where a single table is reachable via multiple FK paths from the subset root triggers this. A concrete real-world example using [dj-stripe](https://github.com/dj-stripe/dj-stripe):

- Subset root: `djstripe_customer` with `subset_conds`
- `djstripe_paymentmethod.customer_id` → `djstripe_customer` (direct path)
- `djstripe_invoice.customer_id` → `djstripe_customer` (direct path)
- `djstripe_invoice.default_payment_method_id` → `djstripe_paymentmethod` (indirect path)

When Greenmask walks the graph from `djstripe_customer`, it encounters `djstripe_paymentmethod` via two routes and calls `addItem("public__djstripe_paymentmethod__ids", ...)` twice, producing an invalid `WITH` clause.

I believe this is related to #265.

## Fix

Track seen CTE names in a `map[string]struct{}` on `cteQuery` and skip `addItem` if the name is already registered. The first definition wins — both paths produce equivalent content for the same table.

## Test plan

- [ ] Run `greenmask dump` against a schema with diamond-shaped FK dependencies and `subset_conds` on the shared ancestor — confirm no 42712 error
- [ ] Confirm existing subset tests still pass