### PR TITLE
feat: interpolate transformer parameters using env vars

### DIFF
--- a/docs/built_in_transformers/index.md
+++ b/docs/built_in_transformers/index.md
@@ -8,6 +8,7 @@ split into the following groups:
 - [Transformation engines](transformation_engines.md) — the type of generator used in transformers. Hash (deterministic)
   and random (randomization)
 - [Parameters templating](parameters_templating.md) — generate static parameters values from templates.
+- [Parameters env vars interpolation](parameters_env_vars_interpolation.md) — inject environment variable values into transformer parameters at dump time.
 - [Transformation conditions](transformation_condition.md) — conditions that can be applied to transformers. If the
   condition is not met, the transformer will not be applied.
 - [Transformation Inheritance](transformation_inheritance.md) — transformation inheritance for partitioned tables and

--- a/docs/built_in_transformers/parameters_env_vars_interpolation.md
+++ b/docs/built_in_transformers/parameters_env_vars_interpolation.md
@@ -1,0 +1,81 @@
+# Parameters environment variables interpolation
+
+## Description
+
+Greenmask supports environment variable interpolation in transformer parameter values using
+[POSIX Parameter Expansion](https://github.com/buildkite/interpolate) syntax. This lets you
+inject secrets or environment-specific values into transformer parameters without hardcoding
+them in the config file.
+
+By default, interpolation is **disabled** for transformer `params` to avoid unintentional
+expansion of literal `$` strings that may exist in the data being processed (e.g. a config
+column that stores shell scripts or template text). To opt in, set `resolve_env: true` on
+the specific transformer.
+
+## Syntax
+
+| Syntax | Description |
+|---|---|
+| `${VAR}` or `$VAR` | Replaced with the value of `VAR`; empty string if `VAR` is unset. |
+| `${VAR:-default}` | Replaced with the value of `VAR`, or `"default"` if `VAR` is unset or empty. |
+| `${VAR-default}` | Replaced with the value of `VAR`, or `"default"` if `VAR` is unset (but not if empty). |
+| `${VAR:-}` | Replaced with an empty string when `VAR` is unset or empty (explicit empty default). |
+| `${VAR?message}` | Replaced with the value of `VAR`; Greenmask exits with `message` if `VAR` is unset. |
+| `$$VAR` | Escape sequence — produces the literal string `$VAR` without any env lookup. |
+
+## Usage
+
+Add `resolve_env: true` to the transformer configuration:
+
+```yaml
+transformers:
+  - name: "Replace"
+    resolve_env: true   # enable env var interpolation for this transformer's params
+    params:
+      value: "${NEW_PASSWORD}"
+      column: "password"
+```
+
+!!! warning
+
+    To apply env vars interpolation set `resolve_env: true` on the specific transformer.
+    Without this flag, parameter values containing `$` are treated as plain strings.
+
+## Example
+
+### Schema
+
+```sql
+create table test (password text);
+insert into test (password) values ('secure');
+```
+
+### Configuration
+
+```yaml title="config.yml"
+dump:
+  transformation:
+    - schema: "public"   # Table schema
+      name: "test"       # Table name
+      transformers:      # List of transformers to apply
+        - name: "Replace"    # Transformer name
+          resolve_env: true  # Enable env var interpolation for params
+          params:            # Transformer parameters
+            value: "${NEW_PASSWORD}"
+            column: "password"   # Column to replace
+```
+
+### Running
+
+```bash
+export NEW_PASSWORD="s3cr3t!"
+greenmask dump ...
+```
+
+The `password` column in every dumped row will be replaced with the value of `NEW_PASSWORD`
+resolved at dump time.
+
+!!! tip
+
+    Use `${VAR?your error message}` to make a variable required. Greenmask will exit with
+    the provided message if the variable is not set, making misconfiguration explicit.

--- a/docs/built_in_transformers/parameters_env_vars_interpolation.md
+++ b/docs/built_in_transformers/parameters_env_vars_interpolation.md
@@ -69,7 +69,8 @@ dump:
 
 ```bash
 export NEW_PASSWORD="s3cr3t!"
-greenmask dump ...
+greenmask --config config.yml validate --data --diff --transformed-only
+greenmask --config config.yaml dump
 ```
 
 The `password` column in every dumped row will be replaced with the value of `NEW_PASSWORD`
@@ -79,3 +80,10 @@ resolved at dump time.
 
     Use `${VAR?your error message}` to make a variable required. Greenmask will exit with
     the provided message if the variable is not set, making misconfiguration explicit.
+
+## Playground
+
+You can try this example interactively using the Greenmask [Playground](../playground.md).
+The playground ships with a pre-configured Docker environment where you can run the schema
+setup above, adjust the config, and execute `greenmask validate` or `greenmask dump` to see
+env var interpolation in action.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,9 @@ dump:
     To apply env vars interpolation to transformer parameters, set `resolve_env: true` on the
     specific transformer. By default it is `false` — parameter values containing `$` are treated
     as plain strings, which prevents accidental expansion of literal dollar signs that may appear
-    in stored data or config values.
+    in stored data or config values. See
+    [Parameters env vars interpolation](built_in_transformers/parameters_env_vars_interpolation.md)
+    for details and examples.
 
 !!! tip
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,11 +52,21 @@ dump:
 
 - Interpolation is applied to all string values in the config during unmarshaling.
 - Transformer `params` values are parsed separately (to preserve key casing) and are **not**
-  subject to env var interpolation.
+  subject to env var interpolation by default. To enable interpolation for a specific transformer,
+  set `resolve_env: true` on it — see
+  [Parameters env vars interpolation](built_in_transformers/parameters_env_vars_interpolation.md)
+  for details and examples.
 - Variable values that contain YAML special characters (`:`, `{`, `}`, `#`, etc.) should be
   enclosed in quotes in the config file to avoid YAML parsing errors.
 - The existing behavior of overriding whole config keys via environment variables (e.g., setting
   `LOG_LEVEL=debug` to override `log.level`) is preserved and unaffected by this feature.
+
+!!! warning
+
+    To apply env vars interpolation to transformer parameters, set `resolve_env: true` on the
+    specific transformer. By default it is `false` — parameter values containing `$` are treated
+    as plain strings, which prevents accidental expansion of literal dollar signs that may appear
+    in stored data or config values.
 
 !!! tip
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block announce %}
-A new version 0.2.18 (2026.03.30) is <a
-  href="https://github.com/GreenmaskIO/greenmask/releases/tag/v0.2.18">released</a>
+A new version 0.2.18 (2026.04.15) is <a
+  href="https://github.com/GreenmaskIO/greenmask/releases/tag/v0.2.19">released</a>
 {% endblock %}
 
 {% block outdated %}

--- a/docs/release_notes/greenmask_0_2_19.md
+++ b/docs/release_notes/greenmask_0_2_19.md
@@ -1,0 +1,17 @@
+# Greenmask 0.2.19
+
+## Changes
+
+* Added environment variable interpolation in transformer parameters via `resolve_env: true` transformer option [#430](https://github.com/GreenmaskIO/greenmask/pull/430)
+
+#### Full Changelog: [v0.2.18...v0.2.19](https://github.com/GreenmaskIO/greenmask/compare/v0.2.18...v0.2.19)
+
+## Links
+
+Feel free to reach out to us if you have any questions or need assistance:
+
+* [Discord](https://discord.gg/tAJegUKSTB)
+* [Email](mailto:support@greenmask.io)
+* [Twitter](https://twitter.com/GreenmaskIO)
+* [Telegram [RU]](https://t.me/greenmask_ru)
+* [DockerHub](https://hub.docker.com/r/greenmask/greenmask)

--- a/internal/db/postgres/context/transformers.go
+++ b/internal/db/postgres/context/transformers.go
@@ -41,7 +41,7 @@ func initTransformer(
 		)
 		return nil, totalWarnings, nil
 	}
-	transformer, warnings, err := td.Instance(ctx, d, c.Params, c.DynamicParams, c.When)
+	transformer, warnings, err := td.Instance(ctx, d, c.Params, c.DynamicParams, c.When, c.ResolveEnv)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to init transformer: %w", err)
 	}

--- a/internal/db/postgres/transformers/dict_test.go
+++ b/internal/db/postgres/transformers/dict_test.go
@@ -42,6 +42,7 @@ func TestDictTransformer_Transform_with_fail(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -87,6 +88,7 @@ func TestDictTransformer_Transform_validation_error(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, warnings)
@@ -104,6 +106,7 @@ func TestDictTransformer_Transform_validation_error(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, warnings)
@@ -125,6 +128,7 @@ func TestDictTransformer_Transform_error_not_matched(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -154,6 +158,7 @@ func TestDictTransformer_Transform_use_default(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -186,6 +191,7 @@ func TestDictTransformer_Transform_with_int_values(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/email_test.go
+++ b/internal/db/postgres/transformers/email_test.go
@@ -223,6 +223,7 @@ func TestRandomEmailTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/hash_test.go
+++ b/internal/db/postgres/transformers/hash_test.go
@@ -78,6 +78,7 @@ func TestHashTransformer_Transform_all_functions(t *testing.T) {
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -156,6 +157,7 @@ func TestHashTransformer_Transform_length_truncation(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -187,6 +189,7 @@ func TestHashTransformer_Transform_multiple_iterations(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/json_test.go
+++ b/internal/db/postgres/transformers/json_test.go
@@ -45,6 +45,7 @@ func TestJsonTransformer_Transform(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
@@ -88,6 +89,7 @@ func TestJsonTransformer_Transform_with_template(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
@@ -133,6 +135,7 @@ func TestJsonTransformer_Transform_null(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
@@ -211,6 +214,7 @@ func TestJsonTransformer_Transform_skip_does_not_exist(t *testing.T) {
 			},
 			nil,
 			"",
+			false,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, warnings)
@@ -251,6 +255,7 @@ func TestJsonTransformer_Transform_skip_does_not_exist(t *testing.T) {
 			},
 			nil,
 			"",
+			false,
 		)
 		require.NoError(t, err)
 		assert.Empty(t, warnings)

--- a/internal/db/postgres/transformers/masking_test.go
+++ b/internal/db/postgres/transformers/masking_test.go
@@ -89,6 +89,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -120,6 +121,7 @@ func TestMaskingTransformer_type_validation(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Len(t, warnings, 1)

--- a/internal/db/postgres/transformers/noise_date_test.go
+++ b/internal/db/postgres/transformers/noise_date_test.go
@@ -120,6 +120,7 @@ func TestNoiseDateTransformer_Transform(t *testing.T) {
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -206,6 +207,7 @@ func TestNoiseDateTransformer_Transform_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/noise_float_test.go
+++ b/internal/db/postgres/transformers/noise_float_test.go
@@ -132,6 +132,7 @@ func TestNoiseFloatTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/noise_int_test.go
+++ b/internal/db/postgres/transformers/noise_int_test.go
@@ -105,6 +105,7 @@ func TestNoiseIntTransformer_Transform(t *testing.T) {
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/noise_numeric_test.go
+++ b/internal/db/postgres/transformers/noise_numeric_test.go
@@ -122,6 +122,7 @@ func TestNoiseNumericTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_bool_test.go
+++ b/internal/db/postgres/transformers/random_bool_test.go
@@ -68,6 +68,7 @@ func TestRandomBoolTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_choice_test.go
+++ b/internal/db/postgres/transformers/random_choice_test.go
@@ -27,6 +27,7 @@ func TestRandomChoiceTransformer_Transform_with_fail(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -59,6 +60,7 @@ func TestRandomChoiceTransformer_Transform_validation_error(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, warnings)
@@ -81,6 +83,7 @@ func TestRandomChoiceTransformer_Transform_json(t *testing.T) {
 		driver, params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_company_test.go
+++ b/internal/db/postgres/transformers/random_company_test.go
@@ -32,6 +32,7 @@ func TestRandomCompanyTransformer_Transform_static_fullname(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -68,6 +69,7 @@ func TestRandomCompanyTransformer_Transform_static_Suffix(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -105,6 +107,7 @@ func TestRandomCompanyTransformer_Transform_static_CompanyName(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -140,6 +143,7 @@ func TestRandomCompanyTransformer_Transform_static_nullable(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_date_test.go
+++ b/internal/db/postgres/transformers/random_date_test.go
@@ -117,6 +117,7 @@ func TestTimestampTransformer_Transform(t *testing.T) {
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_float_test.go
+++ b/internal/db/postgres/transformers/random_float_test.go
@@ -160,6 +160,7 @@ func TestRandomFloatTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_int_test.go
+++ b/internal/db/postgres/transformers/random_int_test.go
@@ -133,6 +133,7 @@ func TestRandomIntTransformer_Transform_random_static(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -208,6 +209,7 @@ func TestRandomIntTransformer_Transform_random_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -288,6 +290,7 @@ func TestRandomIntTransformer_Transform_deterministic_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_ip_test.go
+++ b/internal/db/postgres/transformers/random_ip_test.go
@@ -70,6 +70,7 @@ func TestRandomIpTransformer_Transform_random_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_mac_test.go
+++ b/internal/db/postgres/transformers/random_mac_test.go
@@ -132,6 +132,7 @@ func TestRandomMacTransformer_Transform_random(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_numeric_test.go
+++ b/internal/db/postgres/transformers/random_numeric_test.go
@@ -97,6 +97,7 @@ func TestBigIntTransformer_Transform_random_static(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -178,6 +179,7 @@ func TestBigIntTransformer_Transform_random_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -258,6 +260,7 @@ func TestBigIntTransformer_Transform_deterministic_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_person_test.go
+++ b/internal/db/postgres/transformers/random_person_test.go
@@ -35,6 +35,7 @@ func TestRandomPersonTransformer_Transform_static_fullname(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -73,6 +74,7 @@ func TestRandomPersonTransformer_Transform_static_firstname(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -111,6 +113,7 @@ func TestRandomPersonTransformer_Transform_static_lastname(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -156,6 +159,7 @@ func TestRandomPersonTransformer_Transform_static_nullable(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -203,6 +207,7 @@ func TestRandomPersonTransformer_Transform_keep_null(t *testing.T) {
 			params,
 			nil,
 			"",
+			false,
 		)
 		require.NoError(t, err)
 		require.Empty(t, warnings)
@@ -253,6 +258,7 @@ func TestRandomPersonTransformer_Transform_keep_null(t *testing.T) {
 			params,
 			nil,
 			"",
+			false,
 		)
 		require.NoError(t, err)
 		require.Empty(t, warnings)
@@ -305,6 +311,7 @@ func TestRandomPersonTransformer_Transform_keep_null(t *testing.T) {
 			params,
 			nil,
 			"",
+			false,
 		)
 		require.NoError(t, err)
 		require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_string_test.go
+++ b/internal/db/postgres/transformers/random_string_test.go
@@ -92,6 +92,7 @@ func TestRandomStringTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_unix_timestamp_test.go
+++ b/internal/db/postgres/transformers/random_unix_timestamp_test.go
@@ -126,6 +126,7 @@ func TestUnixTimestampTransformer_Transform__positive_cases__static(t *testing.T
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -202,6 +203,7 @@ func TestUnixTimestampTransformer_Transform_null_cases(t *testing.T) {
 				driver, tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -279,6 +281,7 @@ func TestUnixTimestampTransformer_Transform_dynamic(t *testing.T) {
 				tt.params,
 				tt.dynamicParams,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/random_uuid_test.go
+++ b/internal/db/postgres/transformers/random_uuid_test.go
@@ -77,6 +77,7 @@ func TestUuidTransformer_Transform_uuid_type(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/real_address_test.go
+++ b/internal/db/postgres/transformers/real_address_test.go
@@ -45,6 +45,7 @@ func TestRealAddressTransformer_Transform(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 
 	require.NoError(t, err)
@@ -79,6 +80,7 @@ func TestMakeNewFakeTransformerFunction_parsing_error(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Len(t, warnings, 1)
@@ -106,6 +108,7 @@ func TestMakeNewFakeTransformerFunction_validation_error(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Len(t, warnings, 1)

--- a/internal/db/postgres/transformers/regexp_replace_test.go
+++ b/internal/db/postgres/transformers/regexp_replace_test.go
@@ -53,6 +53,7 @@ func TestRegexpReplaceTransformer_Transform2(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/replace_test.go
+++ b/internal/db/postgres/transformers/replace_test.go
@@ -89,6 +89,7 @@ func TestReplaceTransformer_Transform(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -149,6 +150,7 @@ func TestReplaceTransformer_Transform_with_raw_value(t *testing.T) {
 				tt.params,
 				nil,
 				"",
+				false,
 			)
 			require.NoError(t, err)
 			require.Empty(t, warnings)
@@ -279,6 +281,7 @@ func TestReplaceTransformer_Transform_dynamic(t *testing.T) {
 					tt.params,
 					tt.dynamicParams,
 					"",
+					false,
 				)
 				require.NoError(t, err)
 				require.Empty(t, warnings)
@@ -325,6 +328,7 @@ func TestReplaceTransformer_Transform_with_validation_error(t *testing.T) {
 		params,
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, warnings)

--- a/internal/db/postgres/transformers/set_null_test.go
+++ b/internal/db/postgres/transformers/set_null_test.go
@@ -38,6 +38,7 @@ func TestSetNullTransformer_Transform(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)

--- a/internal/db/postgres/transformers/template_record_test.go
+++ b/internal/db/postgres/transformers/template_record_test.go
@@ -61,6 +61,7 @@ func TestTemplateRecordTransformer_Transform_date(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -111,6 +112,7 @@ func TestTemplateRecordTransformer_Transform_json(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)

--- a/internal/db/postgres/transformers/template_test.go
+++ b/internal/db/postgres/transformers/template_test.go
@@ -49,6 +49,7 @@ func TestTemplateTransformer_Transform_int(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
@@ -88,6 +89,7 @@ func TestTemplateTransformer_Transform_timestamp(t *testing.T) {
 		},
 		nil,
 		"",
+		false,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)

--- a/internal/db/postgres/transformers/utils/definition.go
+++ b/internal/db/postgres/transformers/utils/definition.go
@@ -53,11 +53,13 @@ func (d *TransformerDefinition) SetSchemaValidator(v SchemaValidationFunc) *Tran
 }
 
 func (d *TransformerDefinition) Instance(
-	ctx context.Context, driver *toolkit.Driver, rawParams map[string]toolkit.ParamsValue, dynamicParameters map[string]*toolkit.DynamicParamValue,
-	whenCond string,
+	ctx context.Context, driver *toolkit.Driver, rawParams map[string]toolkit.ParamsValue,
+	dynamicParameters map[string]*toolkit.DynamicParamValue, whenCond string, interpolate bool,
 ) (*TransformerContext, toolkit.ValidationWarnings, error) {
 	// DecodeValue parameters and get the pgcopy of parsed
-	params, parametersWarnings, err := toolkit.InitParameters(driver, d.Parameters, rawParams, dynamicParameters)
+	params, parametersWarnings, err := toolkit.InitParameters(
+		driver, d.Parameters, rawParams, dynamicParameters, interpolate,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/postgres/transformers/utils/definition_test.go
+++ b/internal/db/postgres/transformers/utils/definition_test.go
@@ -100,7 +100,7 @@ func TestDefinition(t *testing.T) {
 		"replace": []byte("2023-08-27 12:08:11.304895"),
 	}
 
-	_, warnings, err := TestTransformerDefinition.Instance(context.Background(), driver, rawParams, nil, "")
+	_, warnings, err := TestTransformerDefinition.Instance(context.Background(), driver, rawParams, nil, "", false)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
 }

--- a/internal/domains/config.go
+++ b/internal/domains/config.go
@@ -124,6 +124,7 @@ type DataRestorationErrorExclusions struct {
 
 type TransformerConfig struct {
 	Name               string `mapstructure:"name" yaml:"name" json:"name,omitempty"`
+	ResolveEnv         bool   `mapstructure:"resolve_env" yaml:"resolve_env" json:"resolve_env,omitempty"`
 	ApplyForReferences bool   `mapstructure:"apply_for_references" yaml:"apply_for_references" json:"apply_for_references,omitempty"`
 	// Params - transformation parameters. It might be any type. If structure should be stored as raw json
 	// This cannot be parsed with mapstructure due to uncontrollable lowercasing

--- a/internal/utils/config/env_interpolate.go
+++ b/internal/utils/config/env_interpolate.go
@@ -15,36 +15,11 @@
 package config
 
 import (
-	"fmt"
-	"os"
 	"reflect"
-	"strings"
 
-	"github.com/buildkite/interpolate"
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/greenmaskio/greenmask/internal/utils/env"
 )
-
-// InterpolateEnvVars expands environment variable references in s using POSIX
-// Parameter Expansion syntax. Returns s unchanged if it contains no '$'.
-//
-// Supported syntax:
-//   - ${VAR}          — value of VAR; empty string if VAR is unset
-//   - $VAR            — same as ${VAR}
-//   - ${VAR:-default} — value of VAR, or "default" if VAR is unset or empty
-//   - ${VAR-default}  — value of VAR, or "default" if VAR is unset (but not if empty)
-//   - ${VAR?message}  — value of VAR; error with "message" if VAR is unset
-//   - $$VAR           — escape sequence, produces the literal string $VAR
-func InterpolateEnvVars(s string) (string, error) {
-	if !strings.Contains(s, "$") {
-		return s, nil
-	}
-	env := interpolate.NewSliceEnv(os.Environ())
-	res, err := interpolate.Interpolate(env, s)
-	if err != nil {
-		return "", fmt.Errorf("interpolate environment variable: %w", err)
-	}
-	return res, nil
-}
 
 // InterpolateEnvVarsHookFunc returns a mapstructure DecodeHookFunc that expands
 // environment variable references in every string field during config unmarshaling.
@@ -55,6 +30,6 @@ func InterpolateEnvVarsHookFunc() mapstructure.DecodeHookFunc {
 			// We can't parse value it's not a string value
 			return data, nil
 		}
-		return InterpolateEnvVars(val)
+		return env.InterpolateEnvVars(val)
 	}
 }

--- a/internal/utils/env/env_interpolate.go
+++ b/internal/utils/env/env_interpolate.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buildkite/interpolate"
+)
+
+// InterpolateEnvVars expands environment variable references in s using POSIX
+// Parameter Expansion syntax. Returns s unchanged if it contains no '$'.
+//
+// Supported syntax:
+//   - ${VAR}          — value of VAR; empty string if VAR is unset
+//   - $VAR            — same as ${VAR}
+//   - ${VAR:-default} — value of VAR, or "default" if VAR is unset or empty
+//   - ${VAR-default}  — value of VAR, or "default" if VAR is unset (but not if empty)
+//   - ${VAR?message}  — value of VAR; error with "message" if VAR is unset
+//   - $$VAR           — escape sequence, produces the literal string $VAR
+func InterpolateEnvVars(s string) (string, error) {
+	if !strings.Contains(s, "$") {
+		return s, nil
+	}
+	env := interpolate.NewSliceEnv(os.Environ())
+	res, err := interpolate.Interpolate(env, s)
+	if err != nil {
+		return "", fmt.Errorf("interpolate environment variable: %w", err)
+	}
+	return res, nil
+}

--- a/internal/utils/env/env_interpolate_test.go
+++ b/internal/utils/env/env_interpolate_test.go
@@ -12,66 +12,64 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package env
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/greenmaskio/greenmask/internal/utils/env"
 )
 
 func TestInterpolateEnvVars(t *testing.T) {
 	t.Run("set variable is expanded", func(t *testing.T) {
 		t.Setenv("GM_TEST_LEVEL", "debug")
-		result, err := env.InterpolateEnvVars("level: ${GM_TEST_LEVEL}")
+		result, err := InterpolateEnvVars("level: ${GM_TEST_LEVEL}")
 		require.NoError(t, err)
 		assert.Equal(t, "level: debug", result)
 	})
 
 	t.Run("unset variable without default returns empty string", func(t *testing.T) {
-		result, err := env.InterpolateEnvVars("level: ${GM_UNSET_VAR_NO_DEFAULT}")
+		result, err := InterpolateEnvVars("level: ${GM_UNSET_VAR_NO_DEFAULT}")
 		require.NoError(t, err)
 		assert.Equal(t, "level: ", result)
 	})
 
 	t.Run("unset variable with default uses default", func(t *testing.T) {
-		result, err := env.InterpolateEnvVars("level: ${GM_UNSET_VAR:-info}")
+		result, err := InterpolateEnvVars("level: ${GM_UNSET_VAR:-info}")
 		require.NoError(t, err)
 		assert.Equal(t, "level: info", result)
 	})
 
 	t.Run("unset variable with explicit empty default returns empty string", func(t *testing.T) {
-		result, err := env.InterpolateEnvVars("prefix: ${GM_UNSET_VAR:-}")
+		result, err := InterpolateEnvVars("prefix: ${GM_UNSET_VAR:-}")
 		require.NoError(t, err)
 		assert.Equal(t, "prefix: ", result)
 	})
 
 	t.Run("empty variable treated as unset when using :-", func(t *testing.T) {
 		t.Setenv("GM_TEST_EMPTY", "")
-		result, err := env.InterpolateEnvVars("level: ${GM_TEST_EMPTY:-warn}")
+		result, err := InterpolateEnvVars("level: ${GM_TEST_EMPTY:-warn}")
 		require.NoError(t, err)
 		assert.Equal(t, "level: warn", result)
 	})
 
 	t.Run("set variable overrides default", func(t *testing.T) {
 		t.Setenv("GM_TEST_FORMAT", "json")
-		result, err := env.InterpolateEnvVars("format: ${GM_TEST_FORMAT:-text}")
+		result, err := InterpolateEnvVars("format: ${GM_TEST_FORMAT:-text}")
 		require.NoError(t, err)
 		assert.Equal(t, "format: json", result)
 	})
 
 	t.Run("required variable with ?message returns error when unset", func(t *testing.T) {
-		_, err := env.InterpolateEnvVars("bucket: ${GM_UNSET_REQUIRED?bucket must be set}")
+		_, err := InterpolateEnvVars("bucket: ${GM_UNSET_REQUIRED?bucket must be set}")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "bucket must be set")
 	})
 
 	t.Run("required variable with ?message succeeds when set", func(t *testing.T) {
 		t.Setenv("GM_TEST_BUCKET", "mybucket")
-		result, err := env.InterpolateEnvVars("bucket: ${GM_TEST_BUCKET?bucket must be set}")
+		result, err := InterpolateEnvVars("bucket: ${GM_TEST_BUCKET?bucket must be set}")
 		require.NoError(t, err)
 		assert.Equal(t, "bucket: mybucket", result)
 	})
@@ -79,34 +77,34 @@ func TestInterpolateEnvVars(t *testing.T) {
 	t.Run("multiple variables in one string", func(t *testing.T) {
 		t.Setenv("GM_TEST_USER", "admin")
 		t.Setenv("GM_TEST_HOST", "localhost")
-		result, err := env.InterpolateEnvVars("dbname: host=${GM_TEST_HOST} user=${GM_TEST_USER}")
+		result, err := InterpolateEnvVars("dbname: host=${GM_TEST_HOST} user=${GM_TEST_USER}")
 		require.NoError(t, err)
 		assert.Equal(t, "dbname: host=localhost user=admin", result)
 	})
 
 	t.Run("escape $$VAR produces literal $VAR", func(t *testing.T) {
-		result, err := env.InterpolateEnvVars("template: $$MY_VAR")
+		result, err := InterpolateEnvVars("template: $$MY_VAR")
 		require.NoError(t, err)
 		assert.Equal(t, "template: $MY_VAR", result)
 	})
 
 	t.Run("go template syntax {{ }} is not affected", func(t *testing.T) {
 		input := `min: '{{ now | tsModify "-30 years" | .EncodeValue }}'`
-		result, err := env.InterpolateEnvVars(input)
+		result, err := InterpolateEnvVars(input)
 		require.NoError(t, err)
 		assert.Equal(t, input, result)
 	})
 
 	t.Run("string without $ is returned unchanged", func(t *testing.T) {
 		input := "level: info\nformat: text\npath: /tmp/greenmask"
-		result, err := env.InterpolateEnvVars(input)
+		result, err := InterpolateEnvVars(input)
 		require.NoError(t, err)
 		assert.Equal(t, input, result)
 	})
 
 	t.Run("variable embedded in larger string", func(t *testing.T) {
 		t.Setenv("GM_TEST_BUCKET", "my-bucket")
-		result, err := env.InterpolateEnvVars("endpoint: http://s3.example.com/${GM_TEST_BUCKET}/prefix")
+		result, err := InterpolateEnvVars("endpoint: http://s3.example.com/${GM_TEST_BUCKET}/prefix")
 		require.NoError(t, err)
 		assert.Equal(t, "endpoint: http://s3.example.com/my-bucket/prefix", result)
 	})
@@ -115,7 +113,7 @@ func TestInterpolateEnvVars(t *testing.T) {
 		t.Setenv("GM_TEST_LOG_LEVEL", "warn")
 		t.Setenv("GM_TEST_DB", "mydb")
 		input := "log:\n  level: ${GM_TEST_LOG_LEVEL}\ndump:\n  pg_dump_options:\n    dbname: ${GM_TEST_DB:-demo}"
-		result, err := env.InterpolateEnvVars(input)
+		result, err := InterpolateEnvVars(input)
 		require.NoError(t, err)
 		assert.Equal(t, "log:\n  level: warn\ndump:\n  pg_dump_options:\n    dbname: mydb", result)
 	})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           - Dynamic parameters: built_in_transformers/dynamic_parameters.md
           - Transformation engines: built_in_transformers/transformation_engines.md
           - Parameters templating: built_in_transformers/parameters_templating.md
+          - Parameters env vars interpolation: built_in_transformers/parameters_env_vars_interpolation.md
           - Transformation conditions: built_in_transformers/transformation_condition.md
           - Transformation inheritance: built_in_transformers/transformation_inheritance.md
           - Standard transformers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - Contributors:
           - Supporting New Postgres: supporting_new_postgres.md
   - Release notes:
+      - Greenmask 0.2.19: release_notes/greenmask_0_2_19.md
       - Greenmask 0.2.18: release_notes/greenmask_0_2_18.md
       - Greenmask 0.2.17: release_notes/greenmask_0_2_17.md
       - Greenmask 0.2.16: release_notes/greenmask_0_2_16.md

--- a/pkg/toolkit/cmd.go
+++ b/pkg/toolkit/cmd.go
@@ -321,7 +321,10 @@ func (c *Cmd) init(ctx context.Context) (Transformer, *Driver, ValidationWarning
 	}
 	warnings = append(warnings, driverWarnings...)
 
-	params, pw, err := InitParameters(driver, c.definition.Parameters, meta.Parameters.Static, meta.Parameters.Dynamic)
+	params, pw, err := InitParameters(
+		driver, c.definition.Parameters,
+		meta.Parameters.Static, meta.Parameters.Dynamic, false,
+	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error parsing parameters: %w", err)
 	}

--- a/pkg/toolkit/dynamic_parameter_test.go
+++ b/pkg/toolkit/dynamic_parameter_test.go
@@ -47,7 +47,7 @@ func TestDynamicParameter_Init_linked_column_parameter_unsupported_types(t *test
 				SetAllowedColumnTypes("int2", "int4", "int8"),
 		)
 
-	columnParam := NewStaticParameter(columnDef, driver)
+	columnParam := NewStaticParameter(columnDef, driver, false)
 	warns, err := columnParam.Init(nil, ParamsValue("id2"))
 	require.NoError(t, err)
 	require.Empty(t, warns)
@@ -90,7 +90,7 @@ func TestDynamicParameter_Init_linked_column_parameter_supported_types(t *testin
 				SetAllowedColumnTypes("date", "timestamp", "timestamptz"),
 		)
 
-	columnParam := NewStaticParameter(columnDef, driver)
+	columnParam := NewStaticParameter(columnDef, driver, false)
 	warns, err := columnParam.Init(nil, ParamsValue("date_date"))
 	require.NoError(t, err)
 	require.Empty(t, warns)

--- a/pkg/toolkit/parameter_definition.go
+++ b/pkg/toolkit/parameter_definition.go
@@ -251,8 +251,11 @@ func (p *ParameterDefinition) SetDynamicMode(v *DynamicModeProperties) *Paramete
 }
 
 func InitParameters(
-	driver *Driver, paramDef []*ParameterDefinition, staticValues map[string]ParamsValue,
+	driver *Driver,
+	paramDef []*ParameterDefinition,
+	staticValues map[string]ParamsValue,
 	dynamicValues map[string]*DynamicParamValue,
+	interpolate bool,
 ) (map[string]Parameterizer, ValidationWarnings, error) {
 
 	var requiredParamsWarns ValidationWarnings
@@ -354,7 +357,7 @@ func InitParameters(
 		value, ok := staticValues[pd.Name]
 		if ok {
 			// TODO: Enrich parameters with ParameterName in Meta
-			sp := NewStaticParameter(pd, driver)
+			sp := NewStaticParameter(pd, driver, interpolate)
 			initWarns, err := sp.Init(nil, value)
 			if err != nil {
 				return nil, warnings, fmt.Errorf("error initializing \"%s\" parameter: %w", pd.Name, err)
@@ -399,7 +402,7 @@ func InitParameters(
 		}
 
 		staticValue := staticValues[pd.Name]
-		sp := NewStaticParameter(pd, driver)
+		sp := NewStaticParameter(pd, driver, interpolate)
 		initWarns, err := sp.Init(columnParams, staticValue)
 		for _, w := range initWarns {
 			w.AddMeta("ParameterName", pd.Name)

--- a/pkg/toolkit/parameter_definition_test.go
+++ b/pkg/toolkit/parameter_definition_test.go
@@ -52,6 +52,7 @@ func TestInitParametersV2(t *testing.T) {
 		[]*ParameterDefinition{column, minDate, maxDate},
 		map[string]ParamsValue{"column": []byte("date_tstz"), "max_date": []byte("2024-01-14 00:00:00.0+00")},
 		map[string]*DynamicParamValue{"min_date": {Column: "date_tstz"}},
+		false,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warns)

--- a/pkg/toolkit/static_parameter.go
+++ b/pkg/toolkit/static_parameter.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"text/template"
 	"time"
+
+	"github.com/greenmaskio/greenmask/internal/utils/env"
 )
 
 type StaticParameter struct {
@@ -25,13 +27,15 @@ type StaticParameter struct {
 	// value - cached parsed value after Scan or Value
 	value any
 	// rawValue - original raw value received from config
-	rawValue ParamsValue
+	rawValue    ParamsValue
+	interpolate bool
 }
 
-func NewStaticParameter(def *ParameterDefinition, driver *Driver) *StaticParameter {
+func NewStaticParameter(def *ParameterDefinition, driver *Driver, interpolate bool) *StaticParameter {
 	return &StaticParameter{
-		definition: def,
-		driver:     driver,
+		definition:  def,
+		driver:      driver,
+		interpolate: interpolate,
 	}
 }
 
@@ -54,8 +58,23 @@ func (sp *StaticParameter) GetDefinition() *ParameterDefinition {
 }
 
 func (sp *StaticParameter) Init(columnParams map[string]*StaticParameter, rawValue ParamsValue) (ValidationWarnings, error) {
-
 	var warnings ValidationWarnings
+
+	if sp.interpolate && rawValue != nil {
+		interpolatedValue, err := env.InterpolateEnvVars(string(rawValue))
+		if err != nil {
+			return ValidationWarnings{
+					NewValidationWarning().
+						SetSeverity(ErrorValidationSeverity).
+						SetMsg("error interpolating environment variables in parameter value").
+						AddMeta("Error", err.Error()).
+						AddMeta("ParameterName", sp.definition.Name).
+						AddMeta("ParameterValue", string(rawValue)),
+				},
+				nil
+		}
+		rawValue = []byte(interpolatedValue)
+	}
 
 	sp.rawValue = slices.Clone(rawValue)
 


### PR DESCRIPTION
Feat:
* interpolate transformer parameters using env vars if resolve_env: true
* Added new transformer parmater resolve_env (default false) - if true it forces env vars interpolation
* Revised docs, added info for the new feature


## Usage

Add `resolve_env: true` to the transformer configuration:

```yaml
transformers:
  - name: "Replace"
    resolve_env: true   # enable env var interpolation for this transformer's params
    params:
      value: "${NEW_PASSWORD}"
      column: "password"
```

!!! warning

    To apply env vars interpolation set `resolve_env: true` on the specific transformer.
    Without this flag, parameter values containing `$` are treated as plain strings.

## Example

### Schema

```sql
create table test (password text);
insert into test (password) values ('secure');
```

### Configuration

```yaml title="config.yml"
dump:
  transformation:
    - schema: "public"   # Table schema
      name: "test"       # Table name
      transformers:      # List of transformers to apply
        - name: "Replace"    # Transformer name
          resolve_env: true  # Enable env var interpolation for params
          params:            # Transformer parameters
            value: "${NEW_PASSWORD}"
            column: "password"   # Column to replace
```

### Running

```bash
export NEW_PASSWORD="s3cr3t!"
greenmask --config config.yml validate --data --diff --transformed-only
greenmask --config config.yaml dump
```

The `password` column in every dumped row will be replaced with the value of `NEW_PASSWORD`
resolved at dump time.
