### PR TITLE
feat: implement create db and schema opts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,25 @@ integration:
                 --renew-anon-volumes --force-recreate \
                 --exit-code-from greenmask --abort-on-container-exit greenmask
 
+local-build:
+	DOCKER_BUILDKIT=1 \
+		docker build \
+			-f docker/greenmask/mysql/main/Dockerfile \
+			. \
+			-t greenmask-from-source:latest \
+			--target main
+
+local-stop:
+	docker compose  -f ./docker-compose-mysql.yml down
+
+local-cleanup: local-stop
+	docker container prune -f
+	docker network prune -f
+	docker volume prune -f
+	docker image prune -f
+
+greenmask-latest:
+	docker compose -f docker-compose-mysql.yml run greenmask
+
+greenmask-from-source: local-build
+	docker compose -f docker-compose-mysql.yml run greenmask-from-source

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -151,6 +151,15 @@ var (
 			IsRequired:       false,
 			Default:          true,
 		},
+		{
+			Name:             "section",
+			Usage:            "Dump only the named section (pre-data, data, post-data). Can be specified multiple times.",
+			ConfigPathPrefix: "dump.options",
+			BindToConfig:     true,
+			Type:             cmd.FlagTypeStringSlice,
+			IsRequired:       false,
+			Default:          []string{},
+		},
 	}
 
 	dumpCmd = cmd.MustCommand(&cobra.Command{

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -61,6 +61,33 @@ var (
 			IsRequired:       false,
 			Default:          false,
 		},
+		{
+			Name:             "create-database",
+			Usage:            "Create databases before restoring schema. Disabled by default.",
+			ConfigPathPrefix: "restore.options",
+			BindToConfig:     true,
+			Type:             cmd.FlagTypeBool,
+			IsRequired:       false,
+			Default:          false,
+		},
+		{
+			Name:             "if-not-exists",
+			Usage:            "Add IF NOT EXISTS to CREATE DATABASE and other object creation statements.",
+			ConfigPathPrefix: "restore.options",
+			BindToConfig:     true,
+			Type:             cmd.FlagTypeBool,
+			IsRequired:       false,
+			Default:          false,
+		},
+		{
+			Name:             "section",
+			Usage:            "Restore only the named section (pre-data, data, post-data). Can be specified multiple times.",
+			ConfigPathPrefix: "restore.options",
+			BindToConfig:     true,
+			Type:             cmd.FlagTypeStringSlice,
+			IsRequired:       false,
+			Default:          []string{},
+		},
 	}
 
 	restoreCmd = cmd.MustCommand(&cobra.Command{

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -98,10 +98,8 @@ services:
     working_dir: /var/lib/playground
     volumes:
       - ./playground/mysql:/var/lib/playground
-    build:
-      dockerfile: docker/greenmask/mysql/main/Dockerfile
-      context: ./
-    platform: linux/amd64
+    image: greenmask-from-source:latest
+    pull_policy: never
     environment:
       MYSQL_USER: root
       MYSQL_PWD: 1234

--- a/docker/greenmask/mysql/main/Dockerfile
+++ b/docker/greenmask/mysql/main/Dockerfile
@@ -14,10 +14,11 @@ COPY . .
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=$(echo ${TARGETVARIANT} | cut -d 'v' -f 2) make build
 
-FROM debian:${DEBIAN_RELEASE}-slim AS mysql
+FROM debian:${DEBIAN_RELEASE}-slim AS main
 
 ARG DEBIAN_RELEASE=bookworm
 ARG MYSQL_VERSION=8.0
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -25,20 +26,22 @@ RUN apt-get update \
 	&& apt-get install -y wget gnupg2 bash-completion bzip2 openssl zstd xz-utils perl \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/debian/ ${DEBIAN_RELEASE} mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list
-
+# The MySQL Community apt repo only publishes amd64 packages for Debian.
+# On other architectures (arm64, etc.) fall back to Debian's default-mysql-client.
 RUN set -eux; \
-	key='BCA4 3417 C3B4 85DD 128E C6D4 B7B3 B788 A8D3 785C'; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-	mkdir -p /etc/apt/keyrings; \
-	gpg --batch --export "$key" > /etc/apt/keyrings/mysql.gpg; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME"
-
-RUN apt-get update \
-	&& apt-get install -y \
-	mysql-community-client \
+	if [ "${TARGETARCH}" = "amd64" ]; then \
+		echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/debian/ ${DEBIAN_RELEASE} mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list; \
+		key='BCA4 3417 C3B4 85DD 128E C6D4 B7B3 B788 A8D3 785C'; \
+		export GNUPGHOME="$(mktemp -d)"; \
+		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+		mkdir -p /etc/apt/keyrings; \
+		gpg --batch --export "$key" > /etc/apt/keyrings/mysql.gpg; \
+		gpgconf --kill all; \
+		rm -rf "$GNUPGHOME"; \
+		apt-get update && apt-get install -y mysql-community-client; \
+	else \
+		apt-get update && apt-get install -y default-mysql-client; \
+	fi \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /var/lib/greenmask/greenmask /usr/bin

--- a/pkg/common/models/stat.go
+++ b/pkg/common/models/stat.go
@@ -146,9 +146,27 @@ func NewDumpStat(
 	}
 }
 
+type DumpSection string
+
+const (
+	DumpSectionPreData  DumpSection = "pre-data"
+	DumpSectionPostData DumpSection = "post-data"
+	DumpSectionData     DumpSection = "data"
+)
+
+func (m DumpSection) Validate() error {
+	switch m {
+	case DumpSectionPreData, DumpSectionPostData, DumpSectionData:
+		return nil
+	default:
+		return fmt.Errorf("value = '%s': %w", string(m), ErrModelValidation)
+	}
+}
+
 type DumpedDatabaseSchemaStat struct {
 	DatabaseName   string      `json:"database_name"`
 	FileName       string      `json:"file_name"`
+	Section        DumpSection `json:"section"`
 	Compression    Compression `json:"compression"`
 	OriginalSize   int64       `json:"original_size"`
 	CompressedSize int64       `json:"compressed_size"`

--- a/pkg/common/restore/processor/processor.go
+++ b/pkg/common/restore/processor/processor.go
@@ -30,7 +30,8 @@ const (
 )
 
 type schemaRestorer interface {
-	RestoreSchema(ctx context.Context) error
+	RestorePreDataSchema(ctx context.Context) error
+	RestorePostDataSchema(ctx context.Context) error
 }
 
 type Config struct {
@@ -38,6 +39,27 @@ type Config struct {
 	RestoreInOrder bool
 	DataOnly       bool
 	SchemaOnly     bool
+	Section        []string
+}
+
+// sectionEnabled reports whether the given section should be restored.
+// When no explicit sections are configured it falls back to the DataOnly/SchemaOnly flags.
+func (p *DefaultRestoreProcessor) sectionEnabled(section commonmodels.DumpSection) bool {
+	if len(p.cfg.Section) == 0 {
+		switch section {
+		case commonmodels.DumpSectionPreData, commonmodels.DumpSectionPostData:
+			return !p.cfg.DataOnly
+		case commonmodels.DumpSectionData:
+			return !p.cfg.SchemaOnly
+		}
+		return true
+	}
+	for _, s := range p.cfg.Section {
+		if commonmodels.DumpSection(s) == section {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Config) SetDefault(ctx context.Context) {
@@ -211,15 +233,21 @@ func (p *DefaultRestoreProcessor) dataRestore(ctx context.Context) error {
 }
 
 func (p *DefaultRestoreProcessor) Run(ctx context.Context) error {
-	if !p.cfg.DataOnly {
-		if err := p.sr.RestoreSchema(ctx); err != nil {
-			return fmt.Errorf("schema restore: %w", err)
+	if p.sectionEnabled(commonmodels.DumpSectionPreData) {
+		if err := p.sr.RestorePreDataSchema(ctx); err != nil {
+			return fmt.Errorf("pre-data schema restore: %w", err)
 		}
 	}
 
-	if !p.cfg.SchemaOnly {
+	if p.sectionEnabled(commonmodels.DumpSectionData) {
 		if err := p.dataRestore(ctx); err != nil {
 			return fmt.Errorf("data restore: %w", err)
+		}
+	}
+
+	if p.sectionEnabled(commonmodels.DumpSectionPostData) {
+		if err := p.sr.RestorePostDataSchema(ctx); err != nil {
+			return fmt.Errorf("post-data schema restore: %w", err)
 		}
 	}
 	return nil

--- a/pkg/common/restore/processor/processor_test.go
+++ b/pkg/common/restore/processor/processor_test.go
@@ -27,7 +27,12 @@ type schemaRestorerMock struct {
 	mock.Mock
 }
 
-func (s *schemaRestorerMock) RestoreSchema(ctx context.Context) error {
+func (s *schemaRestorerMock) RestorePreDataSchema(ctx context.Context) error {
+	args := s.Called(ctx)
+	return args.Error(0)
+}
+
+func (s *schemaRestorerMock) RestorePostDataSchema(ctx context.Context) error {
 	args := s.Called(ctx)
 	return args.Error(0)
 }
@@ -97,8 +102,8 @@ func TestProcessor_Run(t *testing.T) {
 		ctx := context.Background()
 
 		sr := &schemaRestorerMock{}
-		sr.On("RestoreSchema", mock.Anything).
-			Return(nil)
+		sr.On("RestorePreDataSchema", mock.Anything).Return(nil)
+		sr.On("RestorePostDataSchema", mock.Anything).Return(nil)
 
 		// Create 2 tasks.
 		task1 := &restoreTaskMock{}

--- a/pkg/config/dump.go
+++ b/pkg/config/dump.go
@@ -164,6 +164,7 @@ type CommonDumpOptions struct {
 	Jobs                   int      `mapstructure:"jobs" yaml:"jobs" json:"jobs"`
 	Compress               bool     `mapstructure:"compress" yaml:"compress" json:"compress"`
 	Pgzip                  bool     `mapstructure:"pgzip" yaml:"pgzip" json:"pgzip"`
+	Section                []string `mapstructure:"section" yaml:"section" json:"section,omitempty"`
 }
 
 func (o *CommonDumpOptions) GetIncludedTables() []string {

--- a/pkg/config/restore.go
+++ b/pkg/config/restore.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+
 	mysqlcommonconfig "github.com/greenmaskio/greenmask/pkg/mysql/config"
 )
 
@@ -79,6 +81,26 @@ type CommonRestoreOptions struct {
 	SchemaOnly     bool `mapstructure:"schema-only" yaml:"schema-only" json:"schema-only"`
 	Jobs           int  `mapstructure:"jobs" yaml:"jobs" json:"jobs"`
 	RestoreInOrder bool `mapstructure:"restore-in-order" yaml:"restore-in-order" json:"restore-in-order"`
+	// CreateDatabase controls whether greenmask issues CREATE DATABASE statements before restoring schema.
+	CreateDatabase bool `mapstructure:"create-database" yaml:"create-database" json:"create_database"`
+	// IfNotExists adds IF NOT EXISTS to CREATE DATABASE and (in future) other object creation statements.
+	IfNotExists bool     `mapstructure:"if-not-exists" yaml:"if-not-exists" json:"if_not_exists"`
+	Section     []string `mapstructure:"section" yaml:"section" json:"section,omitempty"`
+}
+
+func (o *CommonRestoreOptions) Validate() error {
+	for _, s := range o.Section {
+		if _, ok := knownRestoreSections[s]; !ok {
+			return fmt.Errorf("unknown section %q: must be one of pre-data, data, post-data", s)
+		}
+	}
+	return nil
+}
+
+var knownRestoreSections = map[string]struct{}{
+	"pre-data":  {},
+	"data":      {},
+	"post-data": {},
 }
 
 type Restore struct {

--- a/pkg/mysql/cmdrun/dump/dump.go
+++ b/pkg/mysql/cmdrun/dump/dump.go
@@ -82,6 +82,36 @@ func WithSchemaOnly() Option {
 	}
 }
 
+func WithSections(sections []string) Option {
+	return func(dump *Dump) error {
+		dump.sections = make(map[models.DumpSection]struct{}, len(sections))
+		for _, s := range sections {
+			ss := models.DumpSection(s)
+			if err := ss.Validate(); err != nil {
+				return fmt.Errorf("validate section %q: %w", s, err)
+			}
+			dump.sections[ss] = struct{}{}
+		}
+		return nil
+	}
+}
+
+// sectionEnabled reports whether the given section (pre-data, data, post-data) should be dumped.
+// When no explicit sections are configured it falls back to the dataOnly/schemaOnly flags.
+func (d *Dump) sectionEnabled(section models.DumpSection) bool {
+	if len(d.sections) == 0 {
+		switch section {
+		case models.DumpSectionPreData, models.DumpSectionPostData:
+			return !d.dataOnly
+		case models.DumpSectionData:
+			return !d.schemaOnly
+		}
+		return true
+	}
+	_, ok := d.sections[section]
+	return ok
+}
+
 func WithCompression(
 	enabled bool,
 	pgzip bool,
@@ -161,6 +191,10 @@ func GetMySQLDumpOpts(cfg *config.Config) []Option {
 		opts = append(opts, WithFilter(filter))
 	}
 
+	if len(cfg.Dump.Options.Section) > 0 {
+		opts = append(opts, WithSections(cfg.Dump.Options.Section))
+	}
+
 	format := cfg.Dump.MysqlConfig.DumpFormat
 	if format == "" {
 		format = models.DumpFormatInsert
@@ -207,6 +241,7 @@ type Dump struct {
 	rowsLimit          int64
 	dataOnly           bool
 	schemaOnly         bool
+	sections           map[models.DumpSection]struct{}
 	compressionEnabled bool
 	compressionPgzip   bool
 	// transformedTablesOnly - dump only transformed tables. This is used in validate command.
@@ -350,14 +385,29 @@ func (d *Dump) SchemaDump(ctx context.Context) ([]models.DumpedDatabaseSchemaSta
 	if err != nil {
 		return nil, fmt.Errorf("get environment variables: %w", err)
 	}
-	options := d.cfg.Dump.MysqlConfig.Params()
-	options = append(options, d.cfg.Dump.MysqlConfig.VendorOptions...)
-	sd := schemadump.New(d.cmd, d.st, envs, options, settings, d.compressionEnabled, d.compressionPgzip)
-	res, err := sd.DumpSchema(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("dump schema: %w", err)
+	connParams := d.cfg.Dump.MysqlConfig.Params()
+	vendorOptions := d.cfg.Dump.MysqlConfig.VendorOptions
+	sd := schemadump.New(d.cmd, d.st, envs, connParams, vendorOptions, settings, d.compressionEnabled, d.compressionPgzip)
+
+	var stats []models.DumpedDatabaseSchemaStat
+
+	if d.sectionEnabled(models.DumpSectionPreData) {
+		preDataStats, err := sd.DumpPreDataSchema(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("dump pre-data schema: %w", err)
+		}
+		stats = append(stats, preDataStats...)
 	}
-	return res, nil
+
+	if d.sectionEnabled(models.DumpSectionPostData) {
+		postDataStats, err := sd.DumpPostDataSchema(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("dump post-data schema: %w", err)
+		}
+		stats = append(stats, postDataStats...)
+	}
+
+	return stats, nil
 }
 
 func (d *Dump) DataDump(ctx context.Context) (err error) {
@@ -484,7 +534,7 @@ func (d *Dump) Run(ctx context.Context) (err error) {
 		}
 	}()
 
-	if !d.dataOnly {
+	if d.sectionEnabled(models.DumpSectionPreData) || d.sectionEnabled(models.DumpSectionPostData) {
 		// TODO: You need to implement a wrapper that does not release a lock until
 		//       schema dump is not finished. This requires to achieve consistent
 		//       snapshot for data and schema dump.
@@ -499,7 +549,7 @@ func (d *Dump) Run(ctx context.Context) (err error) {
 		d.dumpedDatabaseSchema = schemaStats
 	}
 
-	if !d.schemaOnly {
+	if d.sectionEnabled("data") {
 		log.Ctx(ctx).Debug().
 			Bool("data_only", d.dataOnly).
 			Bool("schema_only", d.schemaOnly).

--- a/pkg/mysql/cmdrun/restore/restore.go
+++ b/pkg/mysql/cmdrun/restore/restore.go
@@ -112,6 +112,7 @@ func (d *Restore) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("read metadata: %w", err)
 	}
+
 	taskResolver := taskmapper.NewTaskResolver()
 
 	var tp interfaces.RestoreTaskProducer
@@ -136,13 +137,21 @@ func (d *Restore) Run(ctx context.Context) error {
 		)
 	}
 
-	sr := schema.NewRestorer(d.st, &d.cfg.Restore.MysqlConfig, d.cmd, meta.SchemaDump)
+	schemaOpts := []schema.Option{}
+	if d.cfg.Restore.Options.CreateDatabase && len(meta.Databases) > 0 {
+		schemaOpts = append(schemaOpts, schema.WithCreateDatabase(conn, meta.Databases))
+	}
+	if d.cfg.Restore.Options.IfNotExists {
+		schemaOpts = append(schemaOpts, schema.WithIfNotExists())
+	}
+	sr := schema.NewRestorer(d.st, &d.cfg.Restore.MysqlConfig, d.cmd, meta.SchemaDump, schemaOpts...)
 
 	if err := processor.NewDefaultRestoreProcessor(ctx, tp, sr, processor.Config{
 		Jobs:           d.cfg.Restore.Options.Jobs,
 		RestoreInOrder: d.cfg.Restore.Options.RestoreInOrder,
 		DataOnly:       d.cfg.Restore.Options.DataOnly,
 		SchemaOnly:     d.cfg.Restore.Options.SchemaOnly,
+		Section:        d.cfg.Restore.Options.Section,
 	}).Run(ctx); err != nil {
 		return fmt.Errorf("run restore processor: %w", err)
 	}

--- a/pkg/mysql/dump/schema/dump_cli.go
+++ b/pkg/mysql/dump/schema/dump_cli.go
@@ -28,12 +28,30 @@ import (
 
 const executable = "mysqldump"
 
+// sectionFilePrefix maps schema sections to their file name prefix.
+var sectionFilePrefix = map[commonmodels.DumpSection]string{
+	commonmodels.DumpSectionPreData:  "pre",
+	commonmodels.DumpSectionPostData: "post",
+}
+
+// postDataVendorOptions are flags that control triggers/routines/events.
+// They are handled explicitly when building post-data parameters, so they
+// must be excluded from the generic vendor options pass-through.
+var postDataVendorOptions = map[string]bool{
+	"--triggers":         true,
+	"--skip-triggers":    true,
+	"--routines":         true,
+	"--events":           true,
+	"--add-drop-trigger": true,
+}
+
 type Dumper struct {
 	st               interfaces.Storager
 	cmdProducer      utils.CmdProducer
 	executable       string
 	envs             []string
-	mysqlParams      []string
+	mysqlParams      []string // connection/auth params only
+	vendorOptions    []string // user-specified vendor options
 	genericSettings  commonmodels.MysqlDumpRelatedSettings
 	compression      bool
 	compressionPgzip bool
@@ -44,6 +62,7 @@ func New(
 	st interfaces.Storager,
 	envs []string,
 	mysqlParams []string,
+	vendorOptions []string,
 	genericSettings commonmodels.MysqlDumpRelatedSettings,
 	compression bool,
 	compressionPgzip bool,
@@ -54,49 +73,131 @@ func New(
 		st:               st,
 		cmdProducer:      cmd,
 		mysqlParams:      mysqlParams,
+		vendorOptions:    vendorOptions,
 		genericSettings:  genericSettings,
 		compression:      compression,
 		compressionPgzip: compressionPgzip,
 	}
 }
 
-func (d *Dumper) getCliParameter(dbname string) []string {
-	args := []string{"--no-data"} // Dump only schema, no data
+func containsOption(opts []string, opt string) bool {
+	for _, o := range opts {
+		if o == opt {
+			return true
+		}
+	}
+	return false
+}
 
-	args = append(args, d.mysqlParams...)
-
-	// Add ignored tables for this database. Note that mysqldump requires database.table format for --ignore-table
-	// These are named parameters (options) and should come before the positional arguments.
+// addTableFiltering appends ignore-table flags, the database name, and any
+// included table names to args in the order mysqldump expects.
+func (d *Dumper) addTableFiltering(args []string, dbname string) []string {
 	if excludeTables, ok := d.genericSettings.ExcludeTables[dbname]; ok {
 		for _, et := range excludeTables {
 			args = append(args, fmt.Sprintf("--ignore-table=%s.%s", dbname, et))
 		}
 	}
-
-	// Add database name as the first positional argument
 	args = append(args, dbname)
-
-	// Add included tables for this database as subsequent positional arguments
 	if tables, ok := d.genericSettings.IncludeTables[dbname]; ok {
 		args = append(args, tables...)
 	}
-
 	return args
 }
 
-func (d *Dumper) DumpSchema(ctx context.Context) ([]commonmodels.DumpedDatabaseSchemaStat, error) {
-	res := make([]commonmodels.DumpedDatabaseSchemaStat, 0)
+// getPreDataCliParameters builds the mysqldump args for the pre-data section:
+// table structures without triggers, routines, or events.
+func (d *Dumper) getPreDataCliParameters(dbname string) []string {
+	args := []string{
+		"--no-data",
+		"--skip-triggers",
+		"--skip-opt",
+	}
+	args = append(args, d.mysqlParams...)
+	for _, opt := range d.vendorOptions {
+		if !postDataVendorOptions[opt] {
+			args = append(args, opt)
+		}
+	}
+	return d.addTableFiltering(args, dbname)
+}
+
+// getPostDataCliParameters builds the mysqldump args for the post-data section:
+// triggers, routines, and events without any table or data DDL.
+func (d *Dumper) getPostDataCliParameters(dbname string) []string {
+	args := []string{
+		"--no-create-info",
+		"--no-data",
+		"--no-create-db",
+	}
+	args = append(args, d.mysqlParams...)
+
+	// triggers are included by default unless the user explicitly opted out
+	if !containsOption(d.vendorOptions, "--skip-triggers") {
+		args = append(args, "--triggers")
+	}
+	if containsOption(d.vendorOptions, "--routines") {
+		args = append(args, "--routines")
+	}
+	if containsOption(d.vendorOptions, "--events") {
+		args = append(args, "--events")
+	}
+	if containsOption(d.vendorOptions, "--add-drop-trigger") {
+		args = append(args, "--add-drop-trigger")
+	}
+
+	for _, opt := range d.vendorOptions {
+		if !postDataVendorOptions[opt] {
+			args = append(args, opt)
+		}
+	}
+	return d.addTableFiltering(args, dbname)
+}
+
+// DumpPreDataSchema dumps the pre-data section (tables, views — no triggers/routines/events)
+// for every allowed schema.
+func (d *Dumper) DumpPreDataSchema(ctx context.Context) ([]commonmodels.DumpedDatabaseSchemaStat, error) {
+	res := make([]commonmodels.DumpedDatabaseSchemaStat, 0, len(d.genericSettings.AllowedSchemas))
 	for _, dbname := range d.genericSettings.AllowedSchemas {
-		stat, err := d.dumpDatabaseSchema(ctx, dbname)
+		stat, err := d.dumpDatabaseSection(ctx, dbname, commonmodels.DumpSectionPreData)
 		if err != nil {
-			return nil, fmt.Errorf("database '%s': %w", dbname, err)
+			return nil, fmt.Errorf("database '%s' pre-data: %w", dbname, err)
 		}
 		res = append(res, stat)
 	}
 	return res, nil
 }
 
-func (d *Dumper) dumpDatabaseSchema(ctx context.Context, dbname string) (commonmodels.DumpedDatabaseSchemaStat, error) {
+// DumpPostDataSchema dumps the post-data section (triggers, routines, events)
+// for every allowed schema.
+func (d *Dumper) DumpPostDataSchema(ctx context.Context) ([]commonmodels.DumpedDatabaseSchemaStat, error) {
+	res := make([]commonmodels.DumpedDatabaseSchemaStat, 0, len(d.genericSettings.AllowedSchemas))
+	for _, dbname := range d.genericSettings.AllowedSchemas {
+		stat, err := d.dumpDatabaseSection(ctx, dbname, commonmodels.DumpSectionPostData)
+		if err != nil {
+			return nil, fmt.Errorf("database '%s' post-data: %w", dbname, err)
+		}
+		res = append(res, stat)
+	}
+	return res, nil
+}
+
+func (d *Dumper) dumpDatabaseSection(
+	ctx context.Context,
+	dbname string,
+	section commonmodels.DumpSection,
+) (commonmodels.DumpedDatabaseSchemaStat, error) {
+	// Resolve CLI params before creating the pipe. An unknown-section error
+	// here would otherwise leave w and r unclosed (pipe-end leak).
+	var params []string
+	switch section {
+	case commonmodels.DumpSectionPreData:
+		params = d.getPreDataCliParameters(dbname)
+	case commonmodels.DumpSectionPostData:
+		params = d.getPostDataCliParameters(dbname)
+	default:
+		return commonmodels.DumpedDatabaseSchemaStat{}, fmt.Errorf("unknown schema section: %s", section)
+	}
+
 	var r utils.CountReadCloser
 	var w utils.CountWriteCloser
 	if d.compression {
@@ -105,23 +206,24 @@ func (d *Dumper) dumpDatabaseSchema(ctx context.Context, dbname string) (commonm
 		w, r = utils.NewPlainPipe()
 	}
 
-	eg, gtx := errgroup.WithContext(ctx)
-	fileName := fmt.Sprintf("schema_%s.sql", dbname)
+	fileName := fmt.Sprintf("schema_%s_%s.sql", sectionFilePrefix[section], dbname)
 	if d.compression {
 		fileName += ".gz"
 	}
+
 	ctx = log.Ctx(ctx).With().
 		Str("Stage", "SchemaDump").
+		Str("Section", string(section)).
 		Str("Database", dbname).
 		Str("FileName", fileName).
 		Logger().WithContext(ctx)
 
+	eg, gtx := errgroup.WithContext(ctx)
+
 	eg.Go(func() error {
 		defer func() {
 			if err := r.Close(); err != nil {
-				log.Ctx(ctx).Warn().
-					Err(err).
-					Msg("error closing input reader")
+				log.Ctx(ctx).Warn().Err(err).Msg("error closing input reader")
 			}
 		}()
 		if err := d.st.PutObject(gtx, fileName, r); err != nil {
@@ -133,18 +235,16 @@ func (d *Dumper) dumpDatabaseSchema(ctx context.Context, dbname string) (commonm
 	eg.Go(func() error {
 		defer func(w io.Closer) {
 			if err := w.Close(); err != nil {
-				log.Ctx(ctx).Error().
-					Err(err).
-					Msg("error closing output writer")
+				log.Ctx(ctx).Error().Err(err).Msg("error closing output writer")
 			}
 		}(w)
-		params := d.getCliParameter(dbname)
 		cmd, err := d.cmdProducer.Produce(d.executable, params, d.envs, nil)
 		if err != nil {
 			return fmt.Errorf("cannot produce mysqldump command: %w", err)
 		}
-		if err := cmd.ExecuteCmdAndWriteStdout(ctx, w); err != nil {
-			return fmt.Errorf("cannot run mysqldump for database %s: %w", dbname, err)
+		// Use gtx so the subprocess is cancelled if the reader goroutine fails.
+		if err := cmd.ExecuteCmdAndWriteStdout(gtx, w); err != nil {
+			return fmt.Errorf("cannot run mysqldump for database %s section %s: %w", dbname, section, err)
 		}
 		return nil
 	})
@@ -164,6 +264,7 @@ func (d *Dumper) dumpDatabaseSchema(ctx context.Context, dbname string) (commonm
 	return commonmodels.DumpedDatabaseSchemaStat{
 		DatabaseName:   dbname,
 		FileName:       fileName,
+		Section:        section,
 		Compression:    compression,
 		OriginalSize:   w.GetCount(),
 		CompressedSize: r.GetCount(),

--- a/pkg/mysql/dump/schema/dump_cli_test.go
+++ b/pkg/mysql/dump/schema/dump_cli_test.go
@@ -56,7 +56,7 @@ func TestDumpPreDataSchema(t *testing.T) {
 		require.NoError(t, err)
 		st.AssertNumberOfCalls(t, "PutObject", 1)
 
-		require.Equal(t, "--no-data --skip-triggers testdb\n", st.Data.String())
+		require.Equal(t, "--no-data --skip-triggers --skip-opt testdb\n", st.Data.String())
 	})
 
 	t.Run("put object error", func(t *testing.T) {

--- a/pkg/mysql/dump/schema/dump_cli_test.go
+++ b/pkg/mysql/dump/schema/dump_cli_test.go
@@ -27,87 +27,97 @@ import (
 	"github.com/greenmaskio/greenmask/pkg/common/utils"
 )
 
-func TestDumpCli_Run(t *testing.T) {
+func newTestDumper(st *mocks.StorageMock, vendorOptions []string) *Dumper {
+	d := New(
+		utils.NewDefaultCmdProducer(),
+		st,
+		[]string{"_TEST=1"},
+		[]string{},
+		vendorOptions,
+		commonmodels.MysqlDumpRelatedSettings{
+			AllowedSchemas: []string{"testdb"},
+			IncludeTables:  map[string][]string{"testdb": nil},
+		},
+		false,
+		false,
+	)
+	d.executable = "echo"
+	return d
+}
+
+func TestDumpPreDataSchema(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		st := mocks.NewStorageMock()
-		st.On(
-			"PutObject",
-			mock.Anything, "schema_testdb.sql",
-			mock.Anything,
-		).Return(nil)
+		st.On("PutObject", mock.Anything, "schema_pre_testdb.sql", mock.Anything).Return(nil)
 
-		d := New(
-			utils.NewDefaultCmdProducer(),
-			st,
-			[]string{"_TEST=1"},
-			[]string{},
-			commonmodels.MysqlDumpRelatedSettings{
-				AllowedSchemas: []string{"testdb"},
-				IncludeTables:  map[string][]string{"testdb": nil},
-			},
-			false,
-			false,
-		)
-		d.executable = "echo"
+		d := newTestDumper(st, nil)
 		ctx := context.Background()
-		_, err := d.DumpSchema(ctx)
+		_, err := d.DumpPreDataSchema(ctx)
 		require.NoError(t, err)
 		st.AssertNumberOfCalls(t, "PutObject", 1)
 
-		actual := st.Data.String()
-		require.Equal(t, "--no-data testdb\n", actual)
+		require.Equal(t, "--no-data --skip-triggers testdb\n", st.Data.String())
 	})
 
 	t.Run("put object error", func(t *testing.T) {
 		st := mocks.NewStorageMock()
-		st.On(
-			"PutObject",
-			mock.Anything, "schema_testdb.sql",
-			mock.Anything,
-		).Return(errors.New("put error"))
+		st.On("PutObject", mock.Anything, "schema_pre_testdb.sql", mock.Anything).
+			Return(errors.New("put error"))
 
-		d := New(
-			utils.NewDefaultCmdProducer(),
-			st,
-			[]string{"_TEST=1"},
-			[]string{},
-			commonmodels.MysqlDumpRelatedSettings{
-				AllowedSchemas: []string{"testdb"},
-				IncludeTables:  map[string][]string{"testdb": nil},
-			},
-			false,
-			false,
-		)
+		d := newTestDumper(st, nil)
 		ctx := context.Background()
-		_, err := d.DumpSchema(ctx)
+		_, err := d.DumpPreDataSchema(ctx)
 		require.Error(t, err)
 		st.AssertNumberOfCalls(t, "PutObject", 1)
 	})
 
 	t.Run("cmdProducer error", func(t *testing.T) {
 		st := mocks.NewStorageMock()
-		st.On(
-			"PutObject",
-			mock.Anything, "schema_testdb.sql",
-			mock.Anything,
-		).Return(nil)
+		st.On("PutObject", mock.Anything, "schema_pre_testdb.sql", mock.Anything).Return(nil)
 
-		d := New(
-			utils.NewDefaultCmdProducer(),
-			st,
-			[]string{"_TEST=1"},
-			[]string{},
-			commonmodels.MysqlDumpRelatedSettings{
-				AllowedSchemas: []string{"testdb"},
-				IncludeTables:  map[string][]string{"testdb": nil},
-			},
-			false,
-			false,
-		)
+		d := newTestDumper(st, nil)
 		d.executable = "121312 unknown command"
 		ctx := context.Background()
-		_, err := d.DumpSchema(ctx)
+		_, err := d.DumpPreDataSchema(ctx)
 		require.Error(t, err)
+	})
+}
+
+func TestDumpPostDataSchema(t *testing.T) {
+	t.Run("basic includes triggers by default", func(t *testing.T) {
+		st := mocks.NewStorageMock()
+		st.On("PutObject", mock.Anything, "schema_post_testdb.sql", mock.Anything).Return(nil)
+
+		d := newTestDumper(st, nil)
+		ctx := context.Background()
+		_, err := d.DumpPostDataSchema(ctx)
+		require.NoError(t, err)
 		st.AssertNumberOfCalls(t, "PutObject", 1)
+
+		require.Equal(t, "--no-create-info --no-data --no-create-db --triggers testdb\n", st.Data.String())
+	})
+
+	t.Run("skip-triggers vendor option suppresses triggers", func(t *testing.T) {
+		st := mocks.NewStorageMock()
+		st.On("PutObject", mock.Anything, "schema_post_testdb.sql", mock.Anything).Return(nil)
+
+		d := newTestDumper(st, []string{"--skip-triggers"})
+		ctx := context.Background()
+		_, err := d.DumpPostDataSchema(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, "--no-create-info --no-data --no-create-db testdb\n", st.Data.String())
+	})
+
+	t.Run("routines and events included when requested", func(t *testing.T) {
+		st := mocks.NewStorageMock()
+		st.On("PutObject", mock.Anything, "schema_post_testdb.sql", mock.Anything).Return(nil)
+
+		d := newTestDumper(st, []string{"--routines", "--events"})
+		ctx := context.Background()
+		_, err := d.DumpPostDataSchema(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, "--no-create-info --no-data --no-create-db --triggers --routines --events testdb\n", st.Data.String())
 	})
 }

--- a/pkg/mysql/restore/restorers/common.go
+++ b/pkg/mysql/restore/restorers/common.go
@@ -17,6 +17,7 @@ package restorers
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog/log"
@@ -42,7 +43,7 @@ func closeTransaction(ctx context.Context, tx *sql.Tx, execErr error, disableFkC
 		return nil
 	}
 	if execErr != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
 			log.Ctx(ctx).Error().Err(rollbackErr).Msg("failed to rollback transaction")
 		}
 		return nil
@@ -61,7 +62,7 @@ func closeTransaction(ctx context.Context, tx *sql.Tx, execErr error, disableFkC
 	}
 
 	if err := tx.Commit(); err != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
 			log.Ctx(ctx).Error().Err(rollbackErr).Msg("failed to rollback transaction")
 		}
 		return fmt.Errorf("commit transaction: %w", err)

--- a/pkg/mysql/restore/restorers/table_data_restorer_csv.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_csv.go
@@ -209,7 +209,9 @@ func (r *TableDataRestorerCsv) openTx(ctx context.Context, db *sql.DB) (err erro
 	defer func() {
 		if err != nil {
 			r.execErr = err
-			_ = closeTransaction(ctx, tx, r.execErr, r.disableFkChecks, r.disableUniqueChecks)
+			if err := closeTransaction(ctx, tx, r.execErr, r.disableFkChecks, r.disableUniqueChecks); err != nil {
+				log.Ctx(ctx).Error().Err(err).Msg("failed to close transaction in defer")
+			}
 		}
 	}()
 

--- a/pkg/mysql/restore/restorers/table_data_restorer_insert.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_insert.go
@@ -117,7 +117,9 @@ func (r *TableDataRestorerInsert) openTx(ctx context.Context, db *sql.DB) (err e
 	defer func() {
 		if err != nil {
 			r.execErr = err
-			_ = closeTransaction(ctx, tx, r.execErr, r.disableFkChecks, r.disableUniqueChecks)
+			if err := closeTransaction(ctx, tx, r.execErr, r.disableFkChecks, r.disableUniqueChecks); err != nil {
+				log.Ctx(ctx).Error().Err(err).Msg("failed to close transaction in defer")
+			}
 		}
 	}()
 

--- a/pkg/mysql/restore/schema/restore.go
+++ b/pkg/mysql/restore/schema/restore.go
@@ -16,6 +16,7 @@ package schema
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 
@@ -36,14 +37,37 @@ type options interface {
 	Env() ([]string, error)
 }
 
-// Restorer - restores mysql schema from the given storage folder.
-// It expected that schema DDL commands are stored in schema.sql.
+type Option func(*Restorer)
+
+// WithCreateDatabase instructs the restorer to issue CREATE DATABASE statements
+// before restoring the pre-data schema.
+func WithCreateDatabase(conn *sql.DB, databases []string) Option {
+	return func(r *Restorer) {
+		r.conn = conn
+		r.databases = databases
+		r.createDatabase = true
+	}
+}
+
+// WithIfNotExists adds IF NOT EXISTS to CREATE DATABASE statements.
+// Has no effect unless WithCreateDatabase is also applied.
+func WithIfNotExists() Option {
+	return func(r *Restorer) {
+		r.ifNotExists = true
+	}
+}
+
+// Restorer restores a MySQL schema from files stored in the dump directory.
 type Restorer struct {
-	st         interfaces.Storager
-	cfg        options
-	executable string
-	cmd        utils.CmdProducer
-	schemaMeta *commonmodels.SchemaDumpMetadata
+	st             interfaces.Storager
+	cfg            options
+	executable     string
+	cmd            utils.CmdProducer
+	schemaMeta     *commonmodels.SchemaDumpMetadata
+	conn           *sql.DB
+	databases      []string
+	createDatabase bool
+	ifNotExists    bool
 }
 
 func NewRestorer(
@@ -51,14 +75,19 @@ func NewRestorer(
 	connCfg options,
 	cmd utils.CmdProducer,
 	schemaMeta *commonmodels.SchemaDumpMetadata,
+	opts ...Option,
 ) *Restorer {
-	return &Restorer{
+	r := &Restorer{
 		st:         st,
 		cfg:        connCfg,
 		executable: executable,
 		cmd:        cmd,
 		schemaMeta: schemaMeta,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 func (r *Restorer) restoreSchemaData(ctx context.Context, dbName string, f io.Reader) error {
@@ -86,13 +115,62 @@ func (r *Restorer) restoreSchemaData(ctx context.Context, dbName string, f io.Re
 	return nil
 }
 
-func (r *Restorer) RestoreSchema(ctx context.Context) error {
+func (r *Restorer) createDatabases(ctx context.Context) error {
+	for _, db := range r.databases {
+		var stmt string
+		if r.ifNotExists {
+			stmt = fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)
+		} else {
+			stmt = fmt.Sprintf("CREATE DATABASE `%s`", db)
+		}
+		log.Ctx(ctx).Debug().
+			Str("DatabaseName", db).
+			Str("Query", stmt).
+			Msg("creating database")
+		if _, err := r.conn.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("create database %q: %w", db, err)
+		}
+	}
+	return nil
+}
+
+// RestorePreDataSchema restores the pre-data section (tables, views) for all databases.
+// For backward-compatible dumps that have no section set, the file is treated as pre-data.
+func (r *Restorer) RestorePreDataSchema(ctx context.Context) error {
+	if r.schemaMeta == nil {
+		log.Ctx(ctx).Debug().Msg("no schema dump found in metadata")
+		return nil
+	}
+
+	if r.createDatabase && len(r.databases) > 0 {
+		if err := r.createDatabases(ctx); err != nil {
+			return fmt.Errorf("create databases: %w", err)
+		}
+	}
+
+	for _, schemaStat := range r.schemaMeta.DumpedDatabaseSchema {
+		// Backward compat: entries without a section are treated as pre-data.
+		if schemaStat.Section != "" && schemaStat.Section != commonmodels.DumpSectionPreData {
+			continue
+		}
+		if err := r.restoreDatabaseSchema(ctx, schemaStat); err != nil {
+			return fmt.Errorf("database '%s': %w", schemaStat.DatabaseName, err)
+		}
+	}
+	return nil
+}
+
+// RestorePostDataSchema restores the post-data section (triggers, routines, events) for all databases.
+func (r *Restorer) RestorePostDataSchema(ctx context.Context) error {
 	if r.schemaMeta == nil {
 		log.Ctx(ctx).Debug().Msg("no schema dump found in metadata")
 		return nil
 	}
 
 	for _, schemaStat := range r.schemaMeta.DumpedDatabaseSchema {
+		if schemaStat.Section != commonmodels.DumpSectionPostData {
+			continue
+		}
 		if err := r.restoreDatabaseSchema(ctx, schemaStat); err != nil {
 			return fmt.Errorf("database '%s': %w", schemaStat.DatabaseName, err)
 		}
@@ -103,6 +181,7 @@ func (r *Restorer) RestoreSchema(ctx context.Context) error {
 func (r *Restorer) restoreDatabaseSchema(ctx context.Context, schemaStat commonmodels.DumpedDatabaseSchemaStat) error {
 	log.Ctx(ctx).Info().
 		Str("Database", schemaStat.DatabaseName).
+		Str("Section", string(schemaStat.Section)).
 		Str("FileName", schemaStat.FileName).
 		Msg("restoring database schema")
 

--- a/pkg/mysql/restore/schema/restore_test.go
+++ b/pkg/mysql/restore/schema/restore_test.go
@@ -81,6 +81,6 @@ func (s *restoreSuite) TestRestorer_RestoreSchema() {
 		ConnectionOpts: opts,
 		VendorOptions:  []string{"--verbose"},
 	}, utils.NewDefaultCmdProducer(), schemaMeta)
-	err = rr.RestoreSchema(ctx)
+	err = rr.RestorePreDataSchema(ctx)
 	s.Require().NoError(err)
 }

--- a/pkg/mysql/restore/taskproducer/producer.go
+++ b/pkg/mysql/restore/taskproducer/producer.go
@@ -62,10 +62,14 @@ func New(
 	conn mysqlcommonconfig.ConnectionOpts,
 	opts RestoreOptions,
 ) *Producer {
-	taskIDs := make([]models.TaskID, 0, len(meta.DataDump.DumpStat.RestorationItems))
-	for taskID := range meta.DataDump.DumpStat.RestorationItems {
-		taskIDs = append(taskIDs, taskID)
+	var taskIDs []models.TaskID
+	if meta.DataDump != nil {
+		taskIDs = make([]models.TaskID, 0, len(meta.DataDump.DumpStat.RestorationItems))
+		for taskID := range meta.DataDump.DumpStat.RestorationItems {
+			taskIDs = append(taskIDs, taskID)
+		}
 	}
+
 	return &Producer{
 		meta:    meta,
 		st:      st,

--- a/playground/mysql/config-local.yaml
+++ b/playground/mysql/config-local.yaml
@@ -39,18 +39,27 @@ dump:
     - "v1"
     - "daily"
   options:
-    jobs: 4
+#    section:
+#      - pre-data
+#      - data
+#      - post-data
+    jobs: 10
+    include-database:
+      - employees
+      - playground
 
   mysql:
-    options:
-      user: root
-      password: 1234
-      connect-database: employees
-      databases:
-        - employees
-      host: localhost
-      port: 3306
-      add-drop-table: false
+    user: root
+    password: 1234
+    connect-database: employees
+    #    databases:
+    #      - employees
+    host: localhost
+    port: 3306
+    #    add-drop-table: false
+    dump-format: insert
+    #      insert-batch-size: 100000000
+    vendor-options: [ ]
 
   transformation:
     - schema: employees
@@ -78,13 +87,20 @@ dump:
 
 restore:
   options:
-    jobs: 2
-    restore-in-order: true
+    jobs: 10
+    schema-only: true
+#    create-database: true
+#    if-not-exists: true
+#    section:
+#      - pre-data
+#      - post-data
+#      - data
+#    restore-in-order: true
 
   mysql:
-    options:
-      user: root
-      password: 1234
-      connect-database: playground
-      host: localhost
-      port: 3307
+    user: root
+    password: 1234
+    connect-database: playground
+    host: localhost
+    port: 3307
+    disable-fk-checks: true

--- a/playground/mysql/config.yaml
+++ b/playground/mysql/config.yaml
@@ -18,7 +18,7 @@ common:
   tmp_dir: "/tmp"
 
 log:
-  level: "info"
+  level: "debug"
   format: "text"
 
 engine: mysql
@@ -39,15 +39,17 @@ dump:
     jobs: 4
 
   mysql:
-    options:
-      user: root
-      password: 1234
-      connect-database: employees
-      databases:
-        - employees
-      host: playground-mysql-db-original
-      port: 3306
-      add-drop-table: false
+    user: root
+    password: 1234
+    connect-database: employees
+#    databases:
+#      - employees
+    host: playground-mysql-db-original
+    port: 3306
+#    add-drop-table: false
+    dump-format: insert
+#      insert-batch-size: 100000000
+    vendor-options: [ ]
 
   transformation:
     - schema: employees
@@ -75,13 +77,15 @@ dump:
 
 restore:
   options:
-    jobs: 2
-    restore-in-order: true
+    jobs: 10
+    create-database: true
+    if-not-exists: true
+    restore-in-order: false
 
   mysql:
-    options:
-      user: root
-      password: 1234
-      connect-database: playground
-      host: playground-mysql-db-transformed
-      port: 3306
+    user: root
+    password: 1234
+    connect-database: playground
+    host: playground-mysql-db-transformed
+    port: 3306
+    disable-fk-checks: true

--- a/tests/integration/e2e/features/dump/schema.go
+++ b/tests/integration/e2e/features/dump/schema.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dump
+
+import _ "embed"
+
+// SchemaSQL is the full e2e test schema embedded from testdata/schema.sql.
+// It covers all three greenmask dump sections (pre-data, data, post-data) and
+// is used to seed a MySQL test container for e2e dump / restore tests.
+//
+//go:embed testdata/schema.sql
+var SchemaSQL string

--- a/tests/integration/e2e/features/dump/testdata/schema.sql
+++ b/tests/integration/e2e/features/dump/testdata/schema.sql
@@ -1,0 +1,95 @@
+-- Copyright 2025 Greenmask
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- =============================================================================
+-- E2E test schema for greenmask MySQL dump / restore tests.
+--
+-- Covers all three dump sections:
+--   pre-data  — CREATE TABLE definitions
+--   data      — INSERT seed rows
+--   post-data — triggers and stored routines
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- testdb (default database, created by the MySQL container env var)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS test_table (
+  id   INT          NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS excluded_table (
+  id   INT          NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS data_excluded_table (
+  id   INT          NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------------------------------------------------------------
+-- other_db
+-- -----------------------------------------------------------------------------
+
+CREATE DATABASE IF NOT EXISTS other_db;
+
+CREATE TABLE IF NOT EXISTS other_db.other_table (
+  id   INT          NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------------------------------------------------------------
+-- Seed data
+-- -----------------------------------------------------------------------------
+
+INSERT INTO test_table          (name) VALUES ('test1'), ('test2');
+INSERT INTO excluded_table      (name) VALUES ('ex1');
+INSERT INTO data_excluded_table (name) VALUES ('dex1');
+INSERT INTO other_db.other_table (name) VALUES ('other1');
+
+-- -----------------------------------------------------------------------------
+-- Post-data: triggers and stored routines (testdb)
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS trg_test_table_before_insert;
+
+DELIMITER ;;
+
+CREATE TRIGGER trg_test_table_before_insert
+  BEFORE INSERT ON test_table
+  FOR EACH ROW
+  BEGIN
+    IF NEW.name = '' THEN
+      SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'name must not be empty';
+    END IF;
+  END;;
+
+DELIMITER ;
+
+DROP PROCEDURE IF EXISTS get_test_table_count;
+
+DELIMITER ;;
+
+CREATE PROCEDURE get_test_table_count(OUT row_count INT)
+  BEGIN
+    SELECT COUNT(*) INTO row_count FROM test_table;
+  END;;
+
+DELIMITER ;

--- a/tests/integration/features/dump/dump_test.go
+++ b/tests/integration/features/dump/dump_test.go
@@ -123,6 +123,13 @@ func (s *dumpTestSuite) getBaseConfig(ctx context.Context) *config.Config {
 	cfg.Dump.Options.IncludeDatabase = nil
 	cfg.Dump.Options.ExcludeDatabase = nil
 	cfg.Dump.Options.ExcludeTableData = nil
+	cfg.Dump.Options.IncludeTableData = nil
+	cfg.Dump.Options.IncludeTableDefinition = nil
+	cfg.Dump.Options.ExcludeTableDefinition = nil
+	cfg.Dump.MysqlConfig.VendorOptions = nil
+	// Disable compression so test file expectations don't need .gz suffixes.
+	cfg.Dump.Options.Compress = false
+	cfg.Dump.Options.Pgzip = false
 	return cfg
 }
 
@@ -207,7 +214,13 @@ func (s *dumpTestSuite) TestDump() {
 		// Verify results in the storage
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql", "other_db__other_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql",
+			"other_db__other_table.sql",
+			"metadata.json", "heartbeat",
+		)
 
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
@@ -246,7 +259,11 @@ func (s *dumpTestSuite) TestDump() {
 		// Verify results in the storage
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"metadata.json", "heartbeat",
+		)
 
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
@@ -285,11 +302,15 @@ func (s *dumpTestSuite) TestDump() {
 		cfg.Dump.Options.IncludeTable = []string{"testdb.test_table"}
 		st := validate.New("")
 		defer st.Cleanup()
-		expectedCliParams := []string{"testdb.test_table"}
-		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, expectedCliParams, nil)
+		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, nil, nil)
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"testdb__test_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -303,7 +324,13 @@ func (s *dumpTestSuite) TestDump() {
 		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, nil, nil)
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__data_excluded_table.sql", "other_db__other_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"testdb__test_table.sql", "testdb__data_excluded_table.sql",
+			"other_db__other_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -318,7 +345,13 @@ func (s *dumpTestSuite) TestDump() {
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
 		// data_excluded_table.sql should be missing (but it currently fails because ExcludeTableData is not implemented)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__excluded_table.sql", "other_db__other_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql",
+			"other_db__other_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -332,7 +365,11 @@ func (s *dumpTestSuite) TestDump() {
 		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, nil, nil)
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -346,7 +383,11 @@ func (s *dumpTestSuite) TestDump() {
 		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, nil, nil)
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -360,7 +401,11 @@ func (s *dumpTestSuite) TestDump() {
 		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, nil, nil)
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -374,7 +419,11 @@ func (s *dumpTestSuite) TestDump() {
 		cmdProducer, cmdRunner := s.runDump(ctx, cfg, st, nil, nil)
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql", "metadata.json", "heartbeat")
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})
@@ -392,15 +441,13 @@ func (s *dumpTestSuite) TestDump() {
 		files, _, err := st.ListDir(ctx)
 		s.Require().NoError(err)
 
-		// All schemas should be there, but only test_table should have a data file
-		// excluded_table, data_excluded_table, and other_db.other_table should NOT have data files
-		s.requireOnlyFiles(files, "schema.sql", "testdb__test_table.sql", "metadata.json", "heartbeat")
-		// Wait, all tables are discovered by introspector.
-		// Introspector does NOT filter by IncludeTableData.
-		// So schema.sql will contain all tables.
-		// But in Storage, we check which files are present.
-		// If IncludeTableData = ["testdb.test_table"], then only testdb__test_table.sql should be present.
-		// Wait, what about other tables? They should NOT have data files.
+		// All schemas should be there, but only test_table should have a data file.
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"testdb__test_table.sql",
+			"metadata.json", "heartbeat",
+		)
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
 	})

--- a/tests/integration/features/dump/schema_sections_test.go
+++ b/tests/integration/features/dump/schema_sections_test.go
@@ -1,0 +1,339 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dump
+
+import (
+	"context"
+	"io"
+	"slices"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/greenmaskio/greenmask/pkg/common/transformers/registry"
+	"github.com/greenmaskio/greenmask/pkg/config"
+	"github.com/greenmaskio/greenmask/pkg/mysql/cmdrun/dump"
+	"github.com/greenmaskio/greenmask/pkg/storages/validate"
+)
+
+// runSchemaDump sets up a capturing CmdProducerMock and runs the dump.
+// Returns every []string args slice that mysqldump was invoked with, in call order.
+func (s *dumpTestSuite) runSchemaDump(
+	ctx context.Context,
+	cfg *config.Config,
+	st *validate.Storage,
+) (capturedArgs [][]string, cmdProducer *CmdProducerMock) {
+	cmdRunner := &CmdRunnerMock{}
+	cmdRunner.On("ExecuteCmdAndWriteStdout", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			w := args.Get(1).(io.Writer)
+			_, err := w.Write([]byte("-- mock schema content"))
+			s.Require().NoError(err)
+		})
+
+	cmdProducer = &CmdProducerMock{}
+	cmdProducer.On("Produce", "mysqldump", mock.Anything, mock.Anything, mock.Anything).
+		Return(cmdRunner, nil).
+		Run(func(callArgs mock.Arguments) {
+			capturedArgs = append(capturedArgs, callArgs.Get(1).([]string))
+		})
+
+	dumpProcess, err := dump.NewDump(cfg, registry.DefaultTransformerRegistry, st, cmdProducer, dump.GetMySQLDumpOpts(cfg)...)
+	s.Require().NoError(err)
+	s.Require().NoError(dumpProcess.Run(ctx))
+	return capturedArgs, cmdProducer
+}
+
+// filterPreDataArgs returns calls where --skip-triggers is present but --no-create-info is not.
+// Pre-data calls always begin with [--no-data, --skip-triggers, ...].
+func filterPreDataArgs(capturedArgs [][]string) [][]string {
+	var result [][]string
+	for _, args := range capturedArgs {
+		if slices.Contains(args, "--skip-triggers") && !slices.Contains(args, "--no-create-info") {
+			result = append(result, args)
+		}
+	}
+	return result
+}
+
+// filterPostDataArgs returns calls where --no-create-info is present.
+// Post-data calls always begin with [--no-create-info, --no-data, --no-create-db, ...].
+func filterPostDataArgs(capturedArgs [][]string) [][]string {
+	var result [][]string
+	for _, args := range capturedArgs {
+		if slices.Contains(args, "--no-create-info") {
+			result = append(result, args)
+		}
+	}
+	return result
+}
+
+func (s *dumpTestSuite) TestSchemaSections() {
+	ctx := context.Background()
+
+	s.Run("pre-data-params", func() {
+		// Pre-data mysqldump call must use --no-data and --skip-triggers, and must
+		// not carry any post-data flags (--no-create-info, --routines, --events).
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		preDataCalls := filterPreDataArgs(capturedArgs)
+		s.Require().Len(preDataCalls, 1, "expected exactly one pre-data mysqldump call for testdb")
+
+		preArgs := preDataCalls[0]
+		s.Assert().Equal("--no-data", preArgs[0])
+		s.Assert().Equal("--skip-triggers", preArgs[1])
+		s.Assert().True(slices.Contains(preArgs, "testdb"))
+		s.Assert().False(slices.Contains(preArgs, "--no-create-info"), "pre-data must not carry --no-create-info")
+		s.Assert().False(slices.Contains(preArgs, "--routines"), "pre-data must not carry --routines")
+		s.Assert().False(slices.Contains(preArgs, "--events"), "pre-data must not carry --events")
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("post-data-params-default", func() {
+		// Post-data mysqldump call must use --no-create-info, --no-data, --no-create-db,
+		// and include --triggers by default (when no --skip-triggers vendor option is given).
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		postDataCalls := filterPostDataArgs(capturedArgs)
+		s.Require().Len(postDataCalls, 1, "expected exactly one post-data mysqldump call for testdb")
+
+		postArgs := postDataCalls[0]
+		s.Assert().Equal("--no-create-info", postArgs[0])
+		s.Assert().Equal("--no-data", postArgs[1])
+		s.Assert().Equal("--no-create-db", postArgs[2])
+		s.Assert().True(slices.Contains(postArgs, "--triggers"), "post-data must include --triggers by default")
+		s.Assert().False(slices.Contains(postArgs, "--skip-triggers"), "post-data must not contain --skip-triggers")
+		s.Assert().False(slices.Contains(postArgs, "--routines"), "post-data must not carry --routines unless requested")
+		s.Assert().False(slices.Contains(postArgs, "--events"), "post-data must not carry --events unless requested")
+		s.Assert().True(slices.Contains(postArgs, "testdb"))
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("skip-triggers-vendor-option", func() {
+		// When the user sets --skip-triggers in VendorOptions, the post-data call must
+		// omit --triggers entirely. The pre-data call always keeps its own --skip-triggers.
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.MysqlConfig.VendorOptions = []string{"--skip-triggers"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		preDataCalls := filterPreDataArgs(capturedArgs)
+		s.Require().Len(preDataCalls, 1)
+		s.Assert().True(slices.Contains(preDataCalls[0], "--skip-triggers"),
+			"pre-data always emits --skip-triggers")
+
+		postDataCalls := filterPostDataArgs(capturedArgs)
+		s.Require().Len(postDataCalls, 1)
+		postArgs := postDataCalls[0]
+		s.Assert().False(slices.Contains(postArgs, "--triggers"),
+			"post-data must not include --triggers when --skip-triggers is set")
+		s.Assert().False(slices.Contains(postArgs, "--skip-triggers"),
+			"post-data must not forward --skip-triggers")
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("routines-and-events-vendor-options", func() {
+		// --routines and --events are post-data flags: they must appear only in the
+		// post-data call and must be absent from the pre-data call.
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.MysqlConfig.VendorOptions = []string{"--routines", "--events"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		preDataCalls := filterPreDataArgs(capturedArgs)
+		s.Require().Len(preDataCalls, 1)
+		s.Assert().False(slices.Contains(preDataCalls[0], "--routines"),
+			"pre-data must not carry --routines")
+		s.Assert().False(slices.Contains(preDataCalls[0], "--events"),
+			"pre-data must not carry --events")
+
+		postDataCalls := filterPostDataArgs(capturedArgs)
+		s.Require().Len(postDataCalls, 1)
+		postArgs := postDataCalls[0]
+		s.Assert().True(slices.Contains(postArgs, "--routines"),
+			"post-data must include --routines when requested")
+		s.Assert().True(slices.Contains(postArgs, "--events"),
+			"post-data must include --events when requested")
+		s.Assert().True(slices.Contains(postArgs, "--triggers"),
+			"post-data must still include --triggers by default")
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("add-drop-trigger-vendor-option", func() {
+		// --add-drop-trigger is a post-data flag and must not appear in pre-data.
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.MysqlConfig.VendorOptions = []string{"--add-drop-trigger"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		preDataCalls := filterPreDataArgs(capturedArgs)
+		s.Require().Len(preDataCalls, 1)
+		s.Assert().False(slices.Contains(preDataCalls[0], "--add-drop-trigger"),
+			"pre-data must not carry --add-drop-trigger")
+
+		postDataCalls := filterPostDataArgs(capturedArgs)
+		s.Require().Len(postDataCalls, 1)
+		s.Assert().True(slices.Contains(postDataCalls[0], "--add-drop-trigger"),
+			"post-data must include --add-drop-trigger when requested")
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("multi-db-each-db-gets-own-calls", func() {
+		// Each allowed database must get its own pre-data and post-data mysqldump call.
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb", "other_db"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		preDataCalls := filterPreDataArgs(capturedArgs)
+		postDataCalls := filterPostDataArgs(capturedArgs)
+
+		s.Require().Len(preDataCalls, 2, "expected one pre-data call per database")
+		s.Require().Len(postDataCalls, 2, "expected one post-data call per database")
+
+		dbsInPreData := collectDBArgs(preDataCalls)
+		s.Assert().ElementsMatch([]string{"testdb", "other_db"}, dbsInPreData)
+
+		dbsInPostData := collectDBArgs(postDataCalls)
+		s.Assert().ElementsMatch([]string{"testdb", "other_db"}, dbsInPostData)
+
+		files, _, err := st.ListDir(ctx)
+		s.Require().NoError(err)
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"schema_pre_other_db.sql", "schema_post_other_db.sql",
+			"testdb__test_table.sql", "testdb__excluded_table.sql", "testdb__data_excluded_table.sql",
+			"other_db__other_table.sql",
+			"metadata.json", "heartbeat",
+		)
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("schema-only-produces-pre-and-post-files", func() {
+		// schema-only mode must produce both pre-data and post-data schema files and no data files.
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.Options.SchemaOnly = true
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		s.Require().Len(capturedArgs, 2, "schema-only must produce exactly 2 mysqldump calls (pre + post per DB)")
+
+		files, _, err := st.ListDir(ctx)
+		s.Require().NoError(err)
+		s.requireOnlyFiles(files,
+			"schema_pre_testdb.sql", "schema_post_testdb.sql",
+			"metadata.json", "heartbeat",
+		)
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+
+	s.Run("table-filter-applied-to-both-sections", func() {
+		// When IncludeTable restricts which tables are dumped, both pre-data and post-data
+		// calls must carry the same database positional argument.
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.Options.IncludeTable = []string{"testdb.test_table"}
+		st := validate.New("")
+		defer st.Cleanup()
+
+		capturedArgs, cmdProducer := s.runSchemaDump(ctx, cfg, st)
+
+		preDataCalls := filterPreDataArgs(capturedArgs)
+		postDataCalls := filterPostDataArgs(capturedArgs)
+
+		s.Require().Len(preDataCalls, 1)
+		s.Require().Len(postDataCalls, 1)
+
+		// Both calls must contain "testdb" and "test_table" as positional args.
+		s.Assert().True(slices.Contains(preDataCalls[0], "testdb"))
+		s.Assert().True(slices.Contains(preDataCalls[0], "test_table"))
+		s.Assert().True(slices.Contains(postDataCalls[0], "testdb"))
+		s.Assert().True(slices.Contains(postDataCalls[0], "test_table"))
+
+		cmdProducer.AssertExpectations(s.T())
+	})
+}
+
+// collectDBArgs extracts the positional database/table args from a set of captured arg slices.
+// It identifies them as the first arg after the connection params block
+// (i.e. args that are neither flags nor flag values).
+func collectDBArgs(calls [][]string) []string {
+	seen := make(map[string]bool)
+	for _, args := range calls {
+		skipNext := false
+		for _, arg := range args {
+			if skipNext {
+				skipNext = false
+				continue
+			}
+			if arg == "--user" || arg == "--host" || arg == "--port" {
+				skipNext = true
+				continue
+			}
+			if len(arg) > 0 && arg[0] == '-' {
+				continue
+			}
+			// First non-flag arg is the database name.
+			if !seen[arg] {
+				seen[arg] = true
+			}
+			break
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for db := range seen {
+		result = append(result, db)
+	}
+	return result
+}


### PR DESCRIPTION
Changes:
* Revised Makefile to simplify ux for running local env for testing
* Introduced section parameter that works similar to pg_dump in postgresql DBMS
* Split schema dump for (databases,[pre-data|post-data]) chunks.
* Fixed linter warnings
* Set --skip-opt by default for mysqldump

Increment for #222 