### PR TITLE
feat: [MySQL] move INSERT batching and conflict resolution to restore…

### DIFF
--- a/pkg/common/subset/common.go
+++ b/pkg/common/subset/common.go
@@ -33,6 +33,17 @@ const (
 	DialectMySQL    = Dialect(sqlbuilder.MySQL)
 )
 
+func (d Dialect) String() string {
+	switch d {
+	case DialectPostgres:
+		return "postgres"
+	case DialectMySQL:
+		return "mysql"
+	default:
+		return fmt.Sprintf("unknown dialect %d", d)
+	}
+}
+
 // mustGetOneTableFromSCC - retrieves a single table from the strongly connected component (SCC) of the subset graph.
 // If the SCC contains more than one table, it panics.
 func mustGetOneTableFromSCC(scc condensationgraph2.SCC) commonmodels.Table {

--- a/pkg/common/subset/dag_query_builder.go
+++ b/pkg/common/subset/dag_query_builder.go
@@ -75,7 +75,14 @@ func (b dagQueryBuilder) build() (map[int]string, error) {
 	tableAliasMap := make(map[int]string)
 	// Build the main select ... from clause for root table
 	rootTableName := getFullTableName(b.dialect, rootTable, tableAliasMap)
-	sb := sqlbuilder.PostgreSQL.
+	var flavor sqlbuilder.Flavor
+	switch b.dialect {
+	case DialectMySQL:
+		flavor = sqlbuilder.MySQL
+	default:
+		panic(fmt.Sprintf("unsupported dialect: '%s'", b.dialect))
+	}
+	sb := flavor.
 		NewSelectBuilder().
 		Select(
 			fmt.Sprintf("%s.*", rootTableName),

--- a/pkg/common/subset/subset_test.go
+++ b/pkg/common/subset/subset_test.go
@@ -118,7 +118,7 @@ func TestNewSubset(t *testing.T) {
 		}
 
 		tables := []models.Table{tableE, tableA, tableB, tableC, tableD}
-		s, err := NewSubset(tables, DialectPostgres)
+		s, err := NewSubset(tables, DialectMySQL)
 		require.NoError(t, err)
 		require.Len(t, s.subsetGraphs, 5)
 
@@ -160,10 +160,10 @@ func TestNewSubset(t *testing.T) {
 		verifySubGraphs(t, expectedSubGraphs, s)
 		expectedTablesQueries := []string{
 			``,
-			`SELECT "public"."a".* FROM "public"."a" WHERE (public.a.id = 1)`,
-			`SELECT "public"."b".* FROM "public"."b" INNER JOIN "public"."a" ON ("public"."b"."a_id" = "public"."a"."id") WHERE (public.a.id = 1)`,
-			`SELECT "public"."c".* FROM "public"."c" INNER JOIN "public"."b" ON ("public"."c"."b_id" = "public"."b"."id") INNER JOIN "public_a__1" ON ("public"."b"."a_id" = "public_a__1"."id") INNER JOIN "public_a__0" ON ("public"."c"."a_id" = "public_a__0"."id") WHERE (public.c.id = 1) AND (public_a__1.id = 1) AND (public_a__0.id = 1)`,
-			`SELECT "public"."d".* FROM "public"."d" INNER JOIN "public"."c" ON ("public"."d"."c_id" = "public"."c"."id") INNER JOIN "public"."b" ON ("public"."c"."b_id" = "public"."b"."id") INNER JOIN "public_a__1" ON ("public"."b"."a_id" = "public_a__1"."id") INNER JOIN "public_a__0" ON ("public"."c"."a_id" = "public_a__0"."id") WHERE (public.c.id = 1) AND (public_a__1.id = 1) AND (public_a__0.id = 1)`,
+			"SELECT `public`.`a`.* FROM `public`.`a` WHERE (public.a.id = 1)",
+			"SELECT `public`.`b`.* FROM `public`.`b` INNER JOIN `public`.`a` ON (`public`.`b`.`a_id` = `public`.`a`.`id`) WHERE (public.a.id = 1)",
+			"SELECT `public`.`c`.* FROM `public`.`c` INNER JOIN `public`.`b` ON (`public`.`c`.`b_id` = `public`.`b`.`id`) INNER JOIN `public_a__1` ON (`public`.`b`.`a_id` = `public_a__1`.`id`) INNER JOIN `public_a__0` ON (`public`.`c`.`a_id` = `public_a__0`.`id`) WHERE (public.c.id = 1) AND (public_a__1.id = 1) AND (public_a__0.id = 1)",
+			"SELECT `public`.`d`.* FROM `public`.`d` INNER JOIN `public`.`c` ON (`public`.`d`.`c_id` = `public`.`c`.`id`) INNER JOIN `public`.`b` ON (`public`.`c`.`b_id` = `public`.`b`.`id`) INNER JOIN `public_a__1` ON (`public`.`b`.`a_id` = `public_a__1`.`id`) INNER JOIN `public_a__0` ON (`public`.`c`.`a_id` = `public_a__0`.`id`) WHERE (public.c.id = 1) AND (public_a__1.id = 1) AND (public_a__0.id = 1)",
 		}
 		require.Equal(t, expectedTablesQueries, s.tablesQueries)
 	})
@@ -237,13 +237,13 @@ func TestNewSubset(t *testing.T) {
 			},
 		}
 		tables := []models.Table{tableA, tableB, tableC}
-		s, err := NewSubset(tables, DialectPostgres)
+		s, err := NewSubset(tables, DialectMySQL)
 		require.NoError(t, err)
 		verifySubGraphs(t, expectedSubGraphs, s)
 		expectedTablesQueries := []string{
-			`SELECT "public"."a".* FROM "public"."a" WHERE (public.a.id = 1)`,
-			`SELECT "public"."b".* FROM "public"."b" LEFT JOIN "public"."a" ON ("public"."b"."a_id" = "public"."a"."id") WHERE (public.b.id = 1) AND (("public"."b"."a_id" IS NULL) OR (public.a.id = 1))`,
-			`SELECT "public"."c".* FROM "public"."c" LEFT JOIN "public"."b" ON ("public"."c"."b_id" = "public"."b"."id") LEFT JOIN "public"."a" ON ("public"."b"."a_id" = "public"."a"."id") WHERE (public.c.id = 1) AND (("public"."c"."b_id" IS NULL) OR (public.b.id = 1)) AND (("public"."b"."a_id" IS NULL) OR (public.a.id = 1))`,
+			"SELECT `public`.`a`.* FROM `public`.`a` WHERE (public.a.id = 1)",
+			"SELECT `public`.`b`.* FROM `public`.`b` LEFT JOIN `public`.`a` ON (`public`.`b`.`a_id` = `public`.`a`.`id`) WHERE (public.b.id = 1) AND ((`public`.`b`.`a_id` IS NULL) OR (public.a.id = 1))",
+			"SELECT `public`.`c`.* FROM `public`.`c` LEFT JOIN `public`.`b` ON (`public`.`c`.`b_id` = `public`.`b`.`id`) LEFT JOIN `public`.`a` ON (`public`.`b`.`a_id` = `public`.`a`.`id`) WHERE (public.c.id = 1) AND ((`public`.`c`.`b_id` IS NULL) OR (public.b.id = 1)) AND ((`public`.`b`.`a_id` IS NULL) OR (public.a.id = 1))",
 		}
 		require.Equal(t, expectedTablesQueries, s.tablesQueries)
 	})
@@ -271,7 +271,7 @@ func TestNewSubset(t *testing.T) {
 			},
 		}
 		tables := []models.Table{tableA, tableB}
-		s, err := NewSubset(tables, DialectPostgres)
+		s, err := NewSubset(tables, DialectMySQL)
 		require.NoError(t, err)
 
 		order, err := s.GetTopologicalOrder()

--- a/pkg/config/dump.go
+++ b/pkg/config/dump.go
@@ -26,8 +26,7 @@ import (
 */
 
 const (
-	DefaultMaxAllowedPacket       = 0
-	DefaultMaxInsertStatementSize = 4 * 1024 * 1024
+	DefaultMaxAllowedPacket = 0
 )
 
 type Transformers []TransformerConfig
@@ -135,12 +134,11 @@ func (tc TransformationConfig) ToTransformationConfig() []commonmodels.TableConf
 
 type MysqlDumpConfig struct {
 	mysqlcommonconfig.ConnectionOpts `mapstructure:",squash" json:",squash,omitempty"` //nolint:staticcheck
-	DumpFormat                       commonmodels.DumpFormat                           `mapstructure:"dump-format" json:"dump_format,omitempty"`                             // Format for data dump (csv or insert)
-	MaxInsertStatementSize           int                                               `mapstructure:"max-insert-statement-size" json:"max_insert_statement_size,omitempty"` // Max size of a single insert statement in bytes
-	NoTablespaces                    bool                                              `mapstructure:"no-tablespaces" json:"no_databases,omitempty"`                         // Exclude tablespace information (--no-tablespaces)
-	PoolHeartbeatInterval            time.Duration                                     `mapstructure:"pool-heartbeat-interval" json:"pool_heartbeat_interval,omitempty"`     // Interval for connection pool heartbeat in seconds
-	PoolHeartbeatTimeout             time.Duration                                     `mapstructure:"pool-heartbeat-timeout" json:"pool_heartbeat_timeout,omitempty"`       // Timeout for connection pool heartbeat in seconds
-	VendorOptions                    []string                                          `mapstructure:"vendor-options" json:"vendor-options,omitempty"`                       // Arbitrary options for mysqldump
+	DumpFormat                       commonmodels.DumpFormat                           `mapstructure:"dump-format" json:"dump_format,omitempty"`                         // Format for data dump (csv or insert)
+	NoTablespaces                    bool                                              `mapstructure:"no-tablespaces" json:"no_databases,omitempty"`                     // Exclude tablespace information (--no-tablespaces)
+	PoolHeartbeatInterval            time.Duration                                     `mapstructure:"pool-heartbeat-interval" json:"pool_heartbeat_interval,omitempty"` // Interval for connection pool heartbeat in seconds
+	PoolHeartbeatTimeout             time.Duration                                     `mapstructure:"pool-heartbeat-timeout" json:"pool_heartbeat_timeout,omitempty"`   // Timeout for connection pool heartbeat in seconds
+	VendorOptions                    []string                                          `mapstructure:"vendor-options" json:"vendor-options,omitempty"`                   // Arbitrary options for mysqldump
 }
 
 type PostgresqlDumpConfig struct {
@@ -223,8 +221,7 @@ func NewDump() Dump {
 			ConnectionOpts: mysqlcommonconfig.ConnectionOpts{
 				MaxAllowedPacket: DefaultMaxAllowedPacket,
 			},
-			MaxInsertStatementSize: DefaultMaxInsertStatementSize,
-			DumpFormat:             commonmodels.DumpFormatInsert,
+			DumpFormat: commonmodels.DumpFormatInsert,
 		},
 		Options: CommonDumpOptions{
 			Compress: true,

--- a/pkg/config/restore.go
+++ b/pkg/config/restore.go
@@ -47,6 +47,8 @@ type Script struct {
 
 const DefaultMaxFetchWarnings = 10
 
+const DefaultMaxInsertStatementSize = 4 * 1024 * 1024
+
 type MysqlRestoreConfig struct {
 	mysqlcommonconfig.ConnectionOpts `mapstructure:",squash" json:",squash,omitempty"`
 	VendorOptions                    []string `mapstructure:"vendor-options" yaml:"vendor-options" json:"vendor-options,omitempty"`
@@ -55,6 +57,10 @@ type MysqlRestoreConfig struct {
 	MaxFetchWarnings        int  `mapstructure:"max-fetch-warnings" yaml:"max-fetch-warnings" json:"max_fetch_warnings"`
 	DisableForeignKeyChecks bool `mapstructure:"disable-fk-checks" yaml:"disable-fk-checks" json:"disable_fk_checks"`
 	DisableUniqueChecks     bool `mapstructure:"disable-unique-checks" yaml:"disable-unique-checks" json:"disable_unique_checks"`
+	// MaxInsertStatementSize controls the maximum byte size of a single batched INSERT statement.
+	MaxInsertStatementSize int  `mapstructure:"max-insert-statement-size" yaml:"max-insert-statement-size" json:"max_insert_statement_size"`
+	InsertIgnore           bool `mapstructure:"insert-ignore" yaml:"insert-ignore" json:"insert_ignore"`
+	InsertReplace          bool `mapstructure:"insert-replace" yaml:"insert-replace" json:"insert_replace"`
 }
 
 func (r *MysqlRestoreConfig) Validate() error {
@@ -117,7 +123,8 @@ func NewRestore() Restore {
 			ConnectionOpts: mysqlcommonconfig.ConnectionOpts{
 				MaxAllowedPacket: mysqlcommonconfig.DefaultMaxAllowedPacket,
 			},
-			MaxFetchWarnings: DefaultMaxFetchWarnings,
+			MaxFetchWarnings:       DefaultMaxFetchWarnings,
+			MaxInsertStatementSize: DefaultMaxInsertStatementSize,
 		},
 	}
 }

--- a/pkg/mysql/cmdrun/dump/dump.go
+++ b/pkg/mysql/cmdrun/dump/dump.go
@@ -435,8 +435,6 @@ func (d *Dump) DataDump(ctx context.Context) (err error) {
 		taskProducerOpts = append(taskProducerOpts, taskproducer.WithTransformedTablesOnly())
 	}
 	taskProducerOpts = append(taskProducerOpts, taskproducer.WithDumpFormat(d.format))
-	taskProducerOpts = append(taskProducerOpts,
-		taskproducer.WithMaxInsertStatementSize(d.cfg.Dump.MysqlConfig.MaxInsertStatementSize))
 
 	tp, err := taskproducer.New(
 		d.introsp,

--- a/pkg/mysql/cmdrun/restore/restore.go
+++ b/pkg/mysql/cmdrun/restore/restore.go
@@ -121,6 +121,9 @@ func (d *Restore) Run(ctx context.Context) error {
 		MaxFetchWarnings:        d.cfg.Restore.MysqlConfig.MaxFetchWarnings,
 		DisableForeignKeyChecks: d.cfg.Restore.MysqlConfig.DisableForeignKeyChecks,
 		DisableUniqueChecks:     d.cfg.Restore.MysqlConfig.DisableUniqueChecks,
+		InsertIgnore:            d.cfg.Restore.MysqlConfig.InsertIgnore,
+		InsertReplace:           d.cfg.Restore.MysqlConfig.InsertReplace,
+		MaxInsertStatementSize:  d.cfg.Restore.MysqlConfig.MaxInsertStatementSize,
 	}
 
 	if d.cfg.Restore.Options.RestoreInOrder {

--- a/pkg/mysql/dump/streamers/insert_writer.go
+++ b/pkg/mysql/dump/streamers/insert_writer.go
@@ -26,65 +26,34 @@ import (
 	"github.com/greenmaskio/greenmask/pkg/mysql/dbmsdriver"
 )
 
-const (
-	// defaultReservedPacketBytes is the amount of bytes we reserve for safety margin
-	// in each INSERT statement to avoid exceeding max_allowed_packet.
-	defaultReservedPacketBytes = 100
-)
-
-var (
-	// rowSeparatorBytes and insertTerminatorBytes are preallocated to avoid
-	// string allocations during Write and Flush, reducing GC overhead.
-	rowSeparatorBytes     = []byte(",\n")
-	insertTerminatorBytes = []byte(";\n")
-)
-
+// InsertWriter writes one value tuple per line:
+//
+//	(val1,val2,val3)
+//	(val4,val5,val6)
+//
+// No INSERT keyword, table name, commas between rows, or semicolons are written.
+// The INSERT statement is assembled on the restore side, allowing the conflict
+// resolution strategy (INSERT / INSERT IGNORE / REPLACE) and batch size to be
+// chosen at restore time.
 type InsertWriter struct {
-	table                  *models.Table
-	w                      io.Writer
-	vals                   []interface{}
-	rowTemplate            string
-	headerWritten          bool
-	maxInsertStatementSize int
-	currentStatementSize   int
-	header                 []byte
+	table       *models.Table
+	w           io.Writer
+	vals        []interface{}
+	rowTemplate string
 }
 
-func NewInsertWriter(table models.Table, w io.Writer, maxInsertStatementSize int) *InsertWriter {
+func NewInsertWriter(table models.Table, w io.Writer) *InsertWriter {
 	placeholders := make([]string, len(table.Columns))
 	for i := range table.Columns {
 		placeholders[i] = "?"
 	}
 	rowTemplate := "(" + strings.Join(placeholders, ", ") + ")"
-
-	tableName := sqlbuilder.MySQL.Quote(table.Name)
-	if table.Schema != "" {
-		tableName = fmt.Sprintf("%s.%s", sqlbuilder.MySQL.Quote(table.Schema), tableName)
-	}
-	headerStr := fmt.Sprintf("INSERT INTO %s (", tableName)
-	for i, col := range table.Columns {
-		if i > 0 {
-			headerStr += ", "
-		}
-		headerStr += sqlbuilder.MySQL.Quote(col.Name)
-	}
-	headerStr += ") VALUES \n"
 	return &InsertWriter{
-		table:                  &table,
-		w:                      w,
-		vals:                   make([]interface{}, len(table.Columns)),
-		rowTemplate:            rowTemplate,
-		maxInsertStatementSize: maxInsertStatementSize,
-		header:                 []byte(headerStr),
+		table:       &table,
+		w:           w,
+		vals:        make([]interface{}, len(table.Columns)),
+		rowTemplate: rowTemplate,
 	}
-}
-
-func (iw *InsertWriter) writeHeader() error {
-	if _, err := iw.w.Write(iw.header); err != nil {
-		return err
-	}
-	iw.currentStatementSize = len(iw.header)
-	return nil
 }
 
 func (iw *InsertWriter) Write(row [][]byte) error {
@@ -101,45 +70,13 @@ func (iw *InsertWriter) Write(row [][]byte) error {
 		return fmt.Errorf("interpolate row: %w", err)
 	}
 
-	rowSize := len(interpolated)
-	if iw.headerWritten {
-		rowSize += len(rowSeparatorBytes)
-	}
-
-	if iw.headerWritten && iw.currentStatementSize+rowSize+len(insertTerminatorBytes) > iw.maxInsertStatementSize-defaultReservedPacketBytes {
-		if _, err := iw.w.Write(insertTerminatorBytes); err != nil {
-			return fmt.Errorf("terminate insert: %w", err)
-		}
-		iw.headerWritten = false
-		iw.currentStatementSize = 0
-	}
-
-	if !iw.headerWritten {
-		if err := iw.writeHeader(); err != nil {
-			return fmt.Errorf("write header: %w", err)
-		}
-		iw.headerWritten = true
-	} else {
-		if _, err := iw.w.Write(rowSeparatorBytes); err != nil {
-			return fmt.Errorf("write row separator: %w", err)
-		}
-		iw.currentStatementSize += len(rowSeparatorBytes)
-	}
-
-	if _, err := fmt.Fprint(iw.w, interpolated); err != nil {
+	if _, err := fmt.Fprintf(iw.w, "%s\n", interpolated); err != nil {
 		return fmt.Errorf("write row: %w", err)
 	}
-	iw.currentStatementSize += len(interpolated)
-
 	return nil
 }
 
+// Flush is a no-op: each row is written atomically with its newline.
 func (iw *InsertWriter) Flush() error {
-	if iw.headerWritten {
-		if _, err := iw.w.Write(insertTerminatorBytes); err != nil {
-			return fmt.Errorf("terminate insert: %w", err)
-		}
-		iw.headerWritten = false
-	}
 	return nil
 }

--- a/pkg/mysql/dump/streamers/insert_writer_test.go
+++ b/pkg/mysql/dump/streamers/insert_writer_test.go
@@ -2,7 +2,6 @@ package streamers
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +13,7 @@ import (
 
 func TestInsertWriter_Write(t *testing.T) {
 
-	t.Run("single_insert_per_write", func(t *testing.T) {
+	t.Run("single_row", func(t *testing.T) {
 		table := models.Table{
 			Schema: "public",
 			Name:   "users",
@@ -26,43 +25,37 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
+		iw := NewInsertWriter(table, &buf)
 
-		rows := [][][]byte{
-			{[]byte("1"), []byte("John Doe"), []byte("john@example.com")},
-			{[]byte("2"), []byte("Jane Doe"), []byte("jane@example.com")},
-		}
-
-		err := iw.Write(rows[0])
-		assert.NoError(t, err)
-		err = iw.Write(rows[1])
-		assert.NoError(t, err)
-		err = iw.Flush()
+		row := [][]byte{[]byte("1"), []byte("John Doe"), []byte("john@example.com")}
+		err := iw.Write(row)
 		assert.NoError(t, err)
 
-		expected := "INSERT INTO `public`.`users` (`id`, `name`, `email`) VALUES \n('1', 'John Doe', 'john@example.com'),\n('2', 'Jane Doe', 'jane@example.com');\n"
+		expected := "('1', 'John Doe', 'john@example.com')\n"
 		assert.Equal(t, expected, buf.String())
 	})
 
-	t.Run("escaping_identifiers", func(t *testing.T) {
+	t.Run("multiple_rows", func(t *testing.T) {
 		table := models.Table{
-			Name: "order items",
+			Schema: "public",
+			Name:   "users",
 			Columns: []models.Column{
-				{Name: "order id"},
-				{Name: "product-name"},
+				{Name: "id"},
+				{Name: "name"},
 			},
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
+		iw := NewInsertWriter(table, &buf)
 
-		row := [][]byte{[]byte("101"), []byte("Widget")}
-		err := iw.Write(row)
+		err := iw.Write([][]byte{[]byte("1"), []byte("John Doe")})
+		assert.NoError(t, err)
+		err = iw.Write([][]byte{[]byte("2"), []byte("Jane Doe")})
 		assert.NoError(t, err)
 		err = iw.Flush()
 		assert.NoError(t, err)
 
-		expected := "INSERT INTO `order items` (`order id`, `product-name`) VALUES \n('101', 'Widget');\n"
+		expected := "('1', 'John Doe')\n('2', 'Jane Doe')\n"
 		assert.Equal(t, expected, buf.String())
 	})
 
@@ -76,37 +69,13 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
-
-		row := [][]byte{[]byte("1"), []byte("\\N")}
-		err := iw.Write(row)
-		assert.NoError(t, err)
-		err = iw.Flush()
-		assert.NoError(t, err)
-
-		expected := "INSERT INTO `test` (`id`, `val`) VALUES \n('1', NULL);\n"
-		assert.Equal(t, expected, buf.String())
-	})
-
-	t.Run("null_value_sequence", func(t *testing.T) {
-		table := models.Table{
-			Name: "test",
-			Columns: []models.Column{
-				{Name: "id"},
-				{Name: "val"},
-			},
-		}
-
-		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
+		iw := NewInsertWriter(table, &buf)
 
 		row := [][]byte{[]byte("1"), dbmsdriver.NullValueSeq}
 		err := iw.Write(row)
 		assert.NoError(t, err)
-		err = iw.Flush()
-		assert.NoError(t, err)
 
-		expected := "INSERT INTO `test` (`id`, `val`) VALUES \n('1', NULL);\n"
+		expected := "('1', NULL)\n"
 		assert.Equal(t, expected, buf.String())
 	})
 
@@ -120,111 +89,35 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
+		iw := NewInsertWriter(table, &buf)
 
-		// Use RawRecord to prepare the row, ensuring consistent escaping logic
 		rr := rawrecord.NewRawRecord(2, dbmsdriver.NullValueSeq)
 		err := rr.SetColumn(0, models.NewColumnRawValue([]byte("1"), false))
 		assert.NoError(t, err)
-		// Set literal string matching NULL sequence ("\N")
 		err = rr.SetColumn(1, models.NewColumnRawValue(dbmsdriver.NullValueSeq, false))
 		assert.NoError(t, err)
 
 		err = iw.Write(rr.GetRow())
 		assert.NoError(t, err)
-		err = iw.Flush()
-		assert.NoError(t, err)
 
-		// Expected SQL should have the literal string "\N" escaped.
 		// RawRecord escapes "\N" (1 backslash) to "\\N" (2 backslashes).
-		// go-sqlbuilder for MySQL escapes each backslash in the string to two.
-		// So "\\N" (2 backslashes) becomes "\\\\N" (4 backslashes) in the SQL.
-		// In Go string literal, 4 backslashes are written as 8 backslashes.
-		expected := "INSERT INTO `test` (`id`, `val`) VALUES \n('1', '\\\\\\\\N');\n"
+		// go-sqlbuilder for MySQL escapes each backslash to two.
+		// So "\\N" becomes "\\\\N" in the SQL.
+		expected := "('1', '\\\\\\\\N')\n"
 		assert.Equal(t, expected, buf.String())
 	})
 
-	t.Run("escaping_values", func(t *testing.T) {
+	t.Run("flush_is_noop", func(t *testing.T) {
 		table := models.Table{
-			Name: "products",
-			Columns: []models.Column{
-				{Name: "name"},
-				{Name: "description"},
-			},
+			Name:    "empty_table",
+			Columns: []models.Column{{Name: "id"}},
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
-
-		row := [][]byte{
-			[]byte("O'Reilly's Book"),
-			[]byte("Backslash \\ and Quote ' and Newline \n"),
-		}
-		err := iw.Write(row)
-		assert.NoError(t, err)
-		err = iw.Flush()
-		assert.NoError(t, err)
-
-		output := buf.String()
-		// go-sqlbuilder for MySQL uses backslash escaping (\', \\, \n, etc.)
-		assert.Contains(t, output, "'O\\'Reilly\\'s Book'")
-		assert.Contains(t, output, "'Backslash \\\\ and Quote \\' and Newline \\n'")
-		assert.True(t, strings.HasSuffix(output, ";\n"))
-	})
-
-	t.Run("no_writes_for_empty_table", func(t *testing.T) {
-		table := models.Table{
-			Name: "empty_table",
-			Columns: []models.Column{
-				{Name: "id"},
-			},
-		}
-
-		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf, 4*1024*1024)
+		iw := NewInsertWriter(table, &buf)
 
 		err := iw.Flush()
 		assert.NoError(t, err)
-
-		assert.Empty(t, buf.String(), "Expected buffer to be empty for no writes")
-	})
-
-	t.Run("size_based_batching", func(t *testing.T) {
-		table := models.Table{
-			Schema: "public",
-			Name:   "users",
-			Columns: []models.Column{
-				{Name: "id"},
-			},
-		}
-
-		var buf bytes.Buffer
-		headerSize := len("INSERT INTO `public`.`users` (`id`) VALUES \n")
-		rowSize := len("('1')")
-		separatorSize := len(",\n")
-		terminatorSize := len(";\n")
-
-		// Set limit so it fits header + 1 row + terminator, but not 2 rows
-		maxSize := headerSize + rowSize + separatorSize + rowSize + terminatorSize - 1
-		iw := NewInsertWriter(table, &buf, maxSize)
-
-		rows := [][][]byte{
-			{[]byte("1")},
-			{[]byte("2")},
-			{[]byte("3")},
-		}
-
-		err := iw.Write(rows[0])
-		assert.NoError(t, err)
-		err = iw.Write(rows[1])
-		assert.NoError(t, err)
-		err = iw.Write(rows[2])
-		assert.NoError(t, err)
-		err = iw.Flush()
-		assert.NoError(t, err)
-
-		// Expect each row in its own statement because of size limit
-		expected := "INSERT INTO `public`.`users` (`id`) VALUES \n('1');\nINSERT INTO `public`.`users` (`id`) VALUES \n('2');\nINSERT INTO `public`.`users` (`id`) VALUES \n('3');\n"
-		assert.Equal(t, expected, buf.String())
+		assert.Empty(t, buf.String())
 	})
 }

--- a/pkg/mysql/dump/streamers/table_data_writer.go
+++ b/pkg/mysql/dump/streamers/table_data_writer.go
@@ -40,18 +40,17 @@ type RowWriter interface {
 type Option func(*TableDataWriter)
 
 type TableDataWriter struct {
-	st                     interfaces.Storager
-	fileName               string
-	rowWriter              RowWriter
-	cw                     utils.CountWriteCloser
-	cr                     utils.CountReadCloser
-	eg                     *errgroup.Group
-	cancel                 context.CancelFunc
-	table                  *models.Table
-	enabled                bool
-	pgzip                  bool
-	format                 models.DumpFormat
-	maxInsertStatementSize int
+	st        interfaces.Storager
+	fileName  string
+	rowWriter RowWriter
+	cw        utils.CountWriteCloser
+	cr        utils.CountReadCloser
+	eg        *errgroup.Group
+	cancel    context.CancelFunc
+	table     *models.Table
+	enabled   bool
+	pgzip     bool
+	format    models.DumpFormat
 }
 
 func NewTableDataWriter(
@@ -88,12 +87,6 @@ func WithFormat(format models.DumpFormat) Option {
 	}
 }
 
-func WithMaxInsertStatementSize(size int) Option {
-	return func(t *TableDataWriter) {
-		t.maxInsertStatementSize = size
-	}
-}
-
 func WithCompression(enabled bool) Option {
 	return func(t *TableDataWriter) {
 		t.enabled = enabled
@@ -123,7 +116,7 @@ func (t *TableDataWriter) Open(ctx context.Context) error {
 	}
 
 	if t.format == models.DumpFormatInsert {
-		t.rowWriter = NewInsertWriter(*t.table, t.cw, t.maxInsertStatementSize)
+		t.rowWriter = NewInsertWriter(*t.table, t.cw)
 	} else {
 		t.rowWriter = csv.NewWriter(t.cw)
 	}

--- a/pkg/mysql/dump/taskproducer/task_producer.go
+++ b/pkg/mysql/dump/taskproducer/task_producer.go
@@ -48,21 +48,20 @@ func newMysqlTableDriver(
 type Option func(*TaskProducer) error
 
 type TaskProducer struct {
-	introspector           interfaces.Introspector
-	tableConfigs           []models.TableConfig
-	registry               *registry.TransformerRegistry
-	connConfig             mysqlmodels.ConnConfig
-	st                     interfaces.Storager
-	txPool                 *pool.ConsistentTxPool
-	subset                 subset.Subset
-	filter                 models.TaskProducerFilter
-	saveOriginal           bool
-	rowLimit               int64
-	compressionEnabled     bool
-	compressionPgzip       bool
-	transformedTablesOnly  bool
-	dumpFormat             models.DumpFormat
-	maxInsertStatementSize int
+	introspector          interfaces.Introspector
+	tableConfigs          []models.TableConfig
+	registry              *registry.TransformerRegistry
+	connConfig            mysqlmodels.ConnConfig
+	st                    interfaces.Storager
+	txPool                *pool.ConsistentTxPool
+	subset                subset.Subset
+	filter                models.TaskProducerFilter
+	saveOriginal          bool
+	rowLimit              int64
+	compressionEnabled    bool
+	compressionPgzip      bool
+	transformedTablesOnly bool
+	dumpFormat            models.DumpFormat
 }
 
 func WithFilter(
@@ -117,13 +116,6 @@ func WithDumpFormat(format models.DumpFormat) Option {
 		if format != "" {
 			tp.dumpFormat = format
 		}
-		return nil
-	}
-}
-
-func WithMaxInsertStatementSize(size int) Option {
-	return func(tp *TaskProducer) error {
-		tp.maxInsertStatementSize = size
 		return nil
 	}
 }
@@ -207,7 +199,6 @@ func (tp *TaskProducer) initTableDumper(
 		dumpstreamers.WithCompression(tp.compressionEnabled),
 		dumpstreamers.WithPgzip(tp.compressionPgzip),
 		dumpstreamers.WithFormat(tp.dumpFormat),
-		dumpstreamers.WithMaxInsertStatementSize(tp.maxInsertStatementSize),
 	)
 	rawRecord := rawrecord.NewRawRecord(len(tableContext.Table.Columns), dbmsdriver.NullValueSeq)
 	r := record.NewRecord(rawRecord, tableContext.TableDriver)
@@ -235,7 +226,6 @@ func (tp *TaskProducer) initTableRawDumper(
 		dumpstreamers.WithCompression(tp.compressionEnabled),
 		dumpstreamers.WithPgzip(tp.compressionPgzip),
 		dumpstreamers.WithFormat(tp.dumpFormat),
-		dumpstreamers.WithMaxInsertStatementSize(tp.maxInsertStatementSize),
 	)
 	return dumpers.NewTableRawDumper(objectID, tr, tw, tableContext.Table)
 }

--- a/pkg/mysql/restore/restorers/table_data_restorer_csv.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_csv.go
@@ -48,6 +48,8 @@ type TableDataRestorerCsv struct {
 	maxFetchWarnings    int
 	disableFkChecks     bool
 	disableUniqueChecks bool
+	insertIgnore        bool
+	insertReplace       bool
 	db                  *sql.DB
 	tx                  *sql.Tx
 	execErr             error
@@ -72,6 +74,9 @@ type TableRestorerConfig struct {
 	MaxFetchWarnings        int
 	DisableForeignKeyChecks bool
 	DisableUniqueChecks     bool
+	InsertIgnore            bool
+	InsertReplace           bool
+	MaxInsertStatementSize  int
 }
 
 type Option func(v *TableRestorerConfig) error
@@ -112,6 +117,33 @@ func WithUniqueChecks(enabled bool) Option {
 	}
 }
 
+func WithInsertIgnore() Option {
+	return func(v *TableRestorerConfig) error {
+		if v.InsertReplace {
+			return fmt.Errorf("insert-ignore and insert-replace are mutually exclusive")
+		}
+		v.InsertIgnore = true
+		return nil
+	}
+}
+
+func WithInsertReplace() Option {
+	return func(v *TableRestorerConfig) error {
+		if v.InsertIgnore {
+			return fmt.Errorf("insert-ignore and insert-replace are mutually exclusive")
+		}
+		v.InsertReplace = true
+		return nil
+	}
+}
+
+func WithMaxInsertStatementSize(size int) Option {
+	return func(v *TableRestorerConfig) error {
+		v.MaxInsertStatementSize = size
+		return nil
+	}
+}
+
 func NewTableDataRestorerCsv(
 	meta models.RestorationItem,
 	connConfig config.ConnectionOpts,
@@ -145,6 +177,8 @@ func NewTableDataRestorerCsv(
 		maxFetchWarnings:    cfg.MaxFetchWarnings,
 		disableFkChecks:     cfg.DisableForeignKeyChecks,
 		disableUniqueChecks: cfg.DisableUniqueChecks,
+		insertIgnore:        cfg.InsertIgnore,
+		insertReplace:       cfg.InsertReplace,
 	}
 	return res, nil
 }
@@ -158,17 +192,21 @@ func (r *TableDataRestorerCsv) showWarnings(ctx context.Context, db *sql.DB) err
 }
 
 func (r *TableDataRestorerCsv) restoreTable(ctx context.Context, tx *sql.Tx) error {
-	// TODO: REPLACE option
-	// YOU MIGHT WANT TO USE LOAD DATA LOCAL INFILE 'Reader::%s' REPLACE
-	// I think you should implement a replace option in the config.
+	conflictKeyword := ""
+	if r.insertReplace {
+		conflictKeyword = "REPLACE "
+	} else if r.insertIgnore {
+		conflictKeyword = "IGNORE "
+	}
 	query := fmt.Sprintf(
 		`LOAD DATA LOCAL INFILE 'Reader::%s' `+
-			"IGNORE INTO TABLE `%s`.`%s` "+
+			"%sINTO TABLE `%s`.`%s` "+
 			`FIELDS TERMINATED BY ',' `+
 			`ENCLOSED BY '"' `+
 			`ESCAPED BY '\\' `+
 			`LINES TERMINATED BY '\n'`,
 		getFileHandlerName(*r.table),
+		conflictKeyword,
 		r.table.Schema,
 		r.table.Name,
 	)

--- a/pkg/mysql/restore/restorers/table_data_restorer_insert.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_insert.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"strings"
 
-	alocutils "github.com/go-mysql-org/go-mysql/utils"
+	"github.com/huandu/go-sqlbuilder"
 	"github.com/rs/zerolog/log"
 
 	"github.com/greenmaskio/greenmask/pkg/common/interfaces"
@@ -34,23 +34,29 @@ import (
 )
 
 type TableDataRestorerInsert struct {
-	table               *models.Table
-	meta                models.RestorationItem
-	connConfig          config.ConnectionOpts
-	st                  interfaces.Storager
-	taskResolver        interfaces.TaskMapper
-	compress            bool
-	pgzip               bool
-	printWarnings       bool
-	maxFetchWarnings    int
-	disableFkChecks     bool
-	disableUniqueChecks bool
-	reader              io.ReadCloser
-	totalWarnings       int
-	printedCount        int
-	db                  *sql.DB
-	tx                  *sql.Tx
-	execErr             error
+	table                  *models.Table
+	meta                   models.RestorationItem
+	connConfig             config.ConnectionOpts
+	st                     interfaces.Storager
+	taskResolver           interfaces.TaskMapper
+	compress               bool
+	pgzip                  bool
+	printWarnings          bool
+	maxFetchWarnings       int
+	disableFkChecks        bool
+	disableUniqueChecks    bool
+	insertIgnore           bool
+	insertReplace          bool
+	maxInsertStatementSize int
+	// headerLen is the byte length of the INSERT header including "VALUES ",
+	// pre-computed once so that batch size estimation avoids rebuilding the header.
+	headerLen     int
+	reader        io.ReadCloser
+	totalWarnings int
+	printedCount  int
+	db            *sql.DB
+	tx            *sql.Tx
+	execErr       error
 }
 
 func NewTableDataRestorerInsert(
@@ -76,20 +82,76 @@ func NewTableDataRestorerInsert(
 	}
 
 	res := &TableDataRestorerInsert{
-		table:               &table,
-		meta:                meta,
-		connConfig:          connConfig,
-		st:                  st,
-		taskResolver:        taskResolver,
-		compress:            cfg.Compress,
-		pgzip:               cfg.Pgzip,
-		printWarnings:       cfg.PrintWarnings,
-		maxFetchWarnings:    cfg.MaxFetchWarnings,
-		disableFkChecks:     cfg.DisableForeignKeyChecks,
-		disableUniqueChecks: cfg.DisableUniqueChecks,
+		table:                  &table,
+		meta:                   meta,
+		connConfig:             connConfig,
+		st:                     st,
+		taskResolver:           taskResolver,
+		compress:               cfg.Compress,
+		pgzip:                  cfg.Pgzip,
+		printWarnings:          cfg.PrintWarnings,
+		maxFetchWarnings:       cfg.MaxFetchWarnings,
+		disableFkChecks:        cfg.DisableForeignKeyChecks,
+		disableUniqueChecks:    cfg.DisableUniqueChecks,
+		insertIgnore:           cfg.InsertIgnore,
+		insertReplace:          cfg.InsertReplace,
+		maxInsertStatementSize: cfg.MaxInsertStatementSize,
 	}
+	res.headerLen = res.computeHeaderLen()
 
 	return res, nil
+}
+
+// newInsertBuilder creates a fresh InsertBuilder configured with the correct
+// verb (INSERT / INSERT IGNORE / REPLACE), table name, and column list.
+// The table name and column names are quoted for MySQL using backticks.
+func (r *TableDataRestorerInsert) newInsertBuilder() *sqlbuilder.InsertBuilder {
+	ib := sqlbuilder.MySQL.NewInsertBuilder()
+	tableName := sqlbuilder.MySQL.Quote(r.table.Schema) + "." + sqlbuilder.MySQL.Quote(r.table.Name)
+
+	switch {
+	case r.insertReplace:
+		ib.ReplaceInto(tableName)
+	case r.insertIgnore:
+		ib.InsertIgnoreInto(tableName)
+	default:
+		ib.InsertInto(tableName)
+	}
+
+	cols := make([]string, len(r.table.Columns))
+	for i, col := range r.table.Columns {
+		cols[i] = sqlbuilder.MySQL.Quote(col.Name)
+	}
+	ib.Cols(cols...)
+	return ib
+}
+
+// computeHeaderLen returns the byte length of the INSERT header string up to
+// and including "VALUES ", by building a single-row dummy statement and
+// finding where the first tuple starts.
+func (r *TableDataRestorerInsert) computeHeaderLen() int {
+	ib := r.newInsertBuilder()
+	ib.Values(sqlbuilder.Raw("X"))
+	stmt, _ := ib.Build()
+	idx := strings.LastIndex(stmt, "VALUES ")
+	if idx < 0 {
+		return len(stmt)
+	}
+	return idx + len("VALUES ")
+}
+
+// buildBatch builds and executes one INSERT statement from the accumulated tuples.
+// Each element of tuples is a raw line from the dump file, e.g. `('val1', 'val2')`.
+func (r *TableDataRestorerInsert) buildBatch(tuples [][]byte) string {
+	ib := r.newInsertBuilder()
+	for _, tuple := range tuples {
+		// Each line from the file is a complete tuple including outer parens:
+		// ('val1', 'val2'). Strip the outer parens so that Values() re-wraps them.
+		inner := tuple[1 : len(tuple)-1]
+		ib.Values(sqlbuilder.Raw(string(inner)))
+	}
+	stmt, _ := ib.Build()
+	return stmt
 }
 
 func (r *TableDataRestorerInsert) Meta() map[string]any {
@@ -205,52 +267,74 @@ func (r *TableDataRestorerInsert) Restore(ctx context.Context) error {
 }
 
 func (r *TableDataRestorerInsert) restoreTable(ctx context.Context) error {
-	reader := bufio.NewReader(r.reader)
-	var stmt []byte
-	var batchNum int
+	scanner := bufio.NewScanner(r.reader)
 
-	for {
-		line, err := reader.ReadBytes('\n')
-		if err != nil && err != io.EOF {
-			return fmt.Errorf("read sql content at batch %d: %w", batchNum+1, err)
-		}
+	var batch [][]byte
+	batchSize := 0
+	batchNum := 0
+	const separatorLen = 2  // ", " between tuples in the VALUES list
+	const terminatorLen = 1 // ";" appended by Build()
 
-		if len(line) > 0 {
-			stmt = append(stmt, line...)
-		}
-
-		// Check if we reached the end of an INSERT statement.
-		// We trim trailing whitespace (including \r and \n) to be robust against CRLF
-		// and different formatting.
-		trimmed := bytes.TrimSpace(line)
-		if bytes.HasSuffix(trimmed, []byte(";")) || (err == io.EOF && len(stmt) > 0) {
-			batchNum++
-
-			stmtStr := alocutils.ByteSliceToString(stmt)
-
-			if strings.TrimSpace(stmtStr) != "" {
-				_, execErr := r.tx.ExecContext(ctx, stmtStr)
-				if execErr != nil {
-					return fmt.Errorf("execute batch %d: %w", batchNum, execErr)
-				}
-				count, err := showInsertWarnings(ctx, r.db, r.printWarnings, r.maxFetchWarnings, batchNum, &r.printedCount)
-				if err != nil {
-					log.Ctx(ctx).Warn().Err(err).Msg("failed to show warnings after batch")
-				}
-				r.totalWarnings += count
-			}
-			stmt = stmt[:0] // reset without reallocating
-		}
-
-		if err == io.EOF {
-			break
-		}
+	maxSize := r.maxInsertStatementSize
+	if maxSize <= 0 {
+		maxSize = 4 * 1024 * 1024
 	}
 
-	return nil
-}
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		batchNum++
 
-// showWarnings is now handled by showInsertWarnings in restoreTable
+		stmt := r.buildBatch(batch)
+		if _, err := r.tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("execute batch %d: %w", batchNum, err)
+		}
+		count, err := showInsertWarnings(ctx, r.db, r.printWarnings, r.maxFetchWarnings, batchNum, &r.printedCount)
+		if err != nil {
+			log.Ctx(ctx).Warn().Err(err).Msg("failed to show warnings after batch")
+		}
+		r.totalWarnings += count
+
+		batch = batch[:0]
+		batchSize = 0
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		tuple := make([]byte, len(line))
+		copy(tuple, line)
+		tupleLen := len(tuple)
+
+		var newSize int
+		if len(batch) == 0 {
+			newSize = r.headerLen + tupleLen + terminatorLen
+		} else {
+			newSize = batchSize + separatorLen + tupleLen
+		}
+
+		if len(batch) > 0 && newSize > maxSize {
+			if err := flush(); err != nil {
+				return err
+			}
+			newSize = r.headerLen + tupleLen + terminatorLen
+		}
+
+		batch = append(batch, tuple)
+		batchSize = newSize
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan file content: %w", err)
+	}
+
+	return flush()
+}
 
 func (r *TableDataRestorerInsert) closeTx(ctx context.Context) error {
 	return closeTransaction(ctx, r.tx, r.execErr, r.disableFkChecks, r.disableUniqueChecks)

--- a/pkg/mysql/restore/restorers/table_data_restorer_insert_test.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_insert_test.go
@@ -42,16 +42,18 @@ func (s *restoreSuite) TestRestorerInsert_RestoreData() {
 	s.Require().NoError(err, "failed to enable foreign key checks")
 	db.Close()
 
-	sqlContent := `
-		INSERT INTO playground.users (username, email) VALUES 
-		    ('insertUser1', 'insertUser1@example.com'), 
-		    ('insertUser2', 'insertUser2@example.com');
-	`
-	r := strings.NewReader(sqlContent)
+	// Values-only format: one tuple per line
+	fileContent := "('insertUser1', 'insertUser1@example.com')\n" +
+		"('insertUser2', 'insertUser2@example.com')\n"
+	r := strings.NewReader(fileContent)
 
 	table := models.Table{
 		Schema: "playground",
 		Name:   "users",
+		Columns: []models.Column{
+			{Name: "username"},
+			{Name: "email"},
+		},
 	}
 	rawData := utils2.Must(json.Marshal(table))
 	meta := models.RestorationItem{
@@ -108,22 +110,22 @@ func (s *restoreSuite) TestRestorerInsert_RestoreData_Batched() {
 	s.Require().NoError(err, "failed to enable foreign key checks")
 	db.Close()
 
-	sqlContent := `
-		INSERT INTO playground.users (username, email) VALUES 
-		    ('insertUser1', 'insertUser1@example.com'), 
-		    ('insertUser2', 'insertUser2@example.com');
-		INSERT INTO playground.users (username, email) VALUES 
-		    ('insertUser3', 'insertUser3@example.com'), 
-		    ('insertUser4', 'insertUser4@example.com');
-		INSERT INTO playground.users (username, email) VALUES 
-		    ('insertUser5', 'insertUser5@example.com'), 
-		    ('insertUser6', 'insertUser6@example.com');
-	`
-	r := strings.NewReader(sqlContent)
+	// Values-only format: 6 rows that will be split into batches by MaxInsertStatementSize
+	fileContent := "('insertUser1', 'insertUser1@example.com')\n" +
+		"('insertUser2', 'insertUser2@example.com')\n" +
+		"('insertUser3', 'insertUser3@example.com')\n" +
+		"('insertUser4', 'insertUser4@example.com')\n" +
+		"('insertUser5', 'insertUser5@example.com')\n" +
+		"('insertUser6', 'insertUser6@example.com')\n"
+	r := strings.NewReader(fileContent)
 
 	table := models.Table{
 		Schema: "playground",
 		Name:   "users",
+		Columns: []models.Column{
+			{Name: "username"},
+			{Name: "email"},
+		},
 	}
 	rawData := utils2.Must(json.Marshal(table))
 	meta := models.RestorationItem{
@@ -138,7 +140,10 @@ func (s *restoreSuite) TestRestorerInsert_RestoreData_Batched() {
 
 	opts := s.GetRootConnectionOpts(ctx)
 	tr := &dummyTaskMapper{}
-	rr, err := NewTableDataRestorerInsert(meta, opts, st, tr)
+	// Small MaxInsertStatementSize to force batching (fits ~2 rows per batch)
+	rr, err := NewTableDataRestorerInsert(meta, opts, st, tr,
+		WithMaxInsertStatementSize(200),
+	)
 	s.NoError(err)
 	err = rr.Init(ctx)
 	s.Require().NoError(err, "failed to init table data restorer")
@@ -180,19 +185,22 @@ func (s *restoreSuite) TestRestorerInsert_RestoreData_SingleRow() {
 	s.Require().NoError(err, "failed to enable foreign key checks")
 	db.Close()
 
-	sqlContent := `
-		INSERT INTO playground.users (username, email) VALUES ('insertUser1', 'insertUser1@example.com');
-		INSERT INTO playground.users (username, email) VALUES ('insertUser2', 'insertUser2@example.com');
-		INSERT INTO playground.users (username, email) VALUES ('insertUser3', 'insertUser3@example.com');
-		INSERT INTO playground.users (username, email) VALUES ('insertUser4', 'insertUser4@example.com');
-		INSERT INTO playground.users (username, email) VALUES ('insertUser5', 'insertUser5@example.com');
-		INSERT INTO playground.users (username, email) VALUES ('insertUser6', 'insertUser6@example.com');
-	`
-	r := strings.NewReader(sqlContent)
+	// Values-only format: one row per line, forced to batch size 1 by tiny MaxInsertStatementSize
+	fileContent := "('insertUser1', 'insertUser1@example.com')\n" +
+		"('insertUser2', 'insertUser2@example.com')\n" +
+		"('insertUser3', 'insertUser3@example.com')\n" +
+		"('insertUser4', 'insertUser4@example.com')\n" +
+		"('insertUser5', 'insertUser5@example.com')\n" +
+		"('insertUser6', 'insertUser6@example.com')\n"
+	r := strings.NewReader(fileContent)
 
 	table := models.Table{
 		Schema: "playground",
 		Name:   "users",
+		Columns: []models.Column{
+			{Name: "username"},
+			{Name: "email"},
+		},
 	}
 	rawData := utils2.Must(json.Marshal(table))
 	meta := models.RestorationItem{
@@ -207,7 +215,10 @@ func (s *restoreSuite) TestRestorerInsert_RestoreData_SingleRow() {
 
 	opts := s.GetRootConnectionOpts(ctx)
 	tr := &dummyTaskMapper{}
-	rr, err := NewTableDataRestorerInsert(meta, opts, st, tr)
+	// MaxInsertStatementSize=1 forces one row per statement
+	rr, err := NewTableDataRestorerInsert(meta, opts, st, tr,
+		WithMaxInsertStatementSize(1),
+	)
 	s.NoError(err)
 	err = rr.Init(ctx)
 	s.Require().NoError(err, "failed to init table data restorer")
@@ -224,72 +235,6 @@ func (s *restoreSuite) TestRestorerInsert_RestoreData_SingleRow() {
 	err = db.QueryRow("SELECT COUNT(*) FROM playground.users WHERE username LIKE 'insertUser%'").Scan(&count)
 	s.Require().NoError(err, "failed to query restored data")
 	s.Require().Equal(6, count, "restored data count does not match")
-
-	// Final cleanup
-	_, err = db.Exec("SET FOREIGN_KEY_CHECKS = 0")
-	s.Require().NoError(err)
-	_, err = db.Exec("TRUNCATE TABLE playground.users")
-	s.Require().NoError(err)
-	_, err = db.Exec("SET FOREIGN_KEY_CHECKS = 1")
-	s.Require().NoError(err)
-}
-func (s *restoreSuite) TestRestorerInsert_RestoreData_CRLF_TrailingSpaces() {
-	err := utils2.SetDefaultContextLogger(zerolog.LevelDebugValue, utils2.LogFormatText)
-	s.Require().NoError(err)
-	ctx := context.Background()
-
-	db, err := s.GetRootConnection(context.Background())
-	s.Require().NoError(err, "failed to connect to database before test")
-	_, err = db.Exec("SET FOREIGN_KEY_CHECKS = 0")
-	s.Require().NoError(err, "failed to disable foreign key checks")
-	_, err = db.Exec("TRUNCATE TABLE playground.users")
-	s.Require().NoError(err, "failed to truncate table")
-	_, err = db.Exec("SET FOREIGN_KEY_CHECKS = 1")
-	s.Require().NoError(err, "failed to enable foreign key checks")
-	db.Close()
-
-	// Use CRLF (\r\n) and trailing spaces before semicolon
-	sqlContent := "INSERT INTO playground.users (username, email) VALUES \r\n" +
-		"    ('insertUser1', 'insertUser1@example.com'), \r\n" +
-		"    ('insertUser2', 'insertUser2@example.com')  ;   \r\n" +
-		"INSERT INTO playground.users (username, email) VALUES \r\n" +
-		"    ('insertUser3', 'insertUser3@example.com');\r\n"
-	r := strings.NewReader(sqlContent)
-
-	table := models.Table{
-		Schema: "playground",
-		Name:   "users",
-	}
-	rawData := utils2.Must(json.Marshal(table))
-	meta := models.RestorationItem{
-		Filename:         "playground__users.sql",
-		RecordCount:      3,
-		ObjectDefinition: rawData,
-	}
-
-	st := mocks.NewStorageMock()
-	st.On("GetObject", mock.Anything, meta.Filename).
-		Return(io.NopCloser(r), nil)
-
-	opts := s.GetRootConnectionOpts(ctx)
-	tr := &dummyTaskMapper{}
-	rr, err := NewTableDataRestorerInsert(meta, opts, st, tr)
-	s.NoError(err)
-	err = rr.Init(ctx)
-	s.Require().NoError(err, "failed to init table data restorer")
-	err = rr.Restore(ctx)
-	s.Require().NoError(err)
-	err = rr.Close(ctx)
-	s.Require().NoError(err)
-
-	db, err = s.GetRootConnection(context.Background())
-	s.Require().NoError(err, "failed to connect to database")
-	defer db.Close()
-
-	var count int
-	err = db.QueryRow("SELECT COUNT(*) FROM playground.users WHERE username LIKE 'insertUser%'").Scan(&count)
-	s.Require().NoError(err, "failed to query restored data")
-	s.Require().Equal(3, count, "restored data count does not match")
 
 	// Final cleanup
 	_, err = db.Exec("SET FOREIGN_KEY_CHECKS = 0")

--- a/pkg/mysql/restore/taskproducer/producer.go
+++ b/pkg/mysql/restore/taskproducer/producer.go
@@ -34,6 +34,9 @@ type RestoreOptions struct {
 	MaxFetchWarnings        int
 	DisableForeignKeyChecks bool
 	DisableUniqueChecks     bool
+	InsertIgnore            bool
+	InsertReplace           bool
+	MaxInsertStatementSize  int
 }
 
 type dummyTaskMapper struct{}
@@ -117,6 +120,13 @@ func (p *Producer) Task() (interfaces.Restorer, error) {
 			restorers.WithWarnings(p.opts.PrintWarnings, p.opts.MaxFetchWarnings),
 			restorers.WithForeignKeyChecks(p.opts.DisableForeignKeyChecks),
 			restorers.WithUniqueChecks(p.opts.DisableUniqueChecks),
+			restorers.WithMaxInsertStatementSize(p.opts.MaxInsertStatementSize),
+		}
+		if p.opts.InsertIgnore {
+			opts = append(opts, restorers.WithInsertIgnore())
+		}
+		if p.opts.InsertReplace {
+			opts = append(opts, restorers.WithInsertReplace())
 		}
 
 		stat := p.meta.DataDump.DumpStat.TaskStats[taskID]

--- a/pkg/mysql/restore/taskproducer/producer_with_order.go
+++ b/pkg/mysql/restore/taskproducer/producer_with_order.go
@@ -136,6 +136,13 @@ func (p *ProducerWithOrder) Task() (interfaces.Restorer, error) {
 			restorers.WithWarnings(p.opts.PrintWarnings, p.opts.MaxFetchWarnings),
 			restorers.WithForeignKeyChecks(p.opts.DisableForeignKeyChecks),
 			restorers.WithUniqueChecks(p.opts.DisableUniqueChecks),
+			restorers.WithMaxInsertStatementSize(p.opts.MaxInsertStatementSize),
+		}
+		if p.opts.InsertIgnore {
+			opts = append(opts, restorers.WithInsertIgnore())
+		}
+		if p.opts.InsertReplace {
+			opts = append(opts, restorers.WithInsertReplace())
 		}
 		stat := p.meta.DataDump.DumpStat.TaskStats[currentTaskID]
 		switch stat.ObjectStat.Format {


### PR DESCRIPTION
Dump now writes one value tuple per line with no INSERT header; the restore side assembles batched INSERT statements via go-sqlbuilder, choosing the conflict keyword (INSERT / INSERT IGNORE / REPLACE INTO) and max statement size at restore time. MaxInsertStatementSize, InsertIgnore, and InsertReplace are moved from dump config to restore config. Also fixes dag_query_builder to use MySQL flavor instead of PostgreSQL, and adds Dialect.String() for error messages.

Increment for #222 