### PR TITLE
feat: [MySQL] add hex-blob support for BINARY/VARBINARY/BLOB dump

### DIFF
--- a/pkg/config/dump.go
+++ b/pkg/config/dump.go
@@ -135,6 +135,7 @@ func (tc TransformationConfig) ToTransformationConfig() []commonmodels.TableConf
 type MysqlDumpConfig struct {
 	mysqlcommonconfig.ConnectionOpts `mapstructure:",squash" json:",squash,omitempty"` //nolint:staticcheck
 	DumpFormat                       commonmodels.DumpFormat                           `mapstructure:"dump-format" json:"dump_format,omitempty"`                         // Format for data dump (csv or insert)
+	HexBlob                          bool                                              `mapstructure:"hex-blob" json:"hex_blob,omitempty"`                               // Encode BINARY/VARBINARY/BLOB columns as X'...' hex literals
 	NoTablespaces                    bool                                              `mapstructure:"no-tablespaces" json:"no_databases,omitempty"`                     // Exclude tablespace information (--no-tablespaces)
 	PoolHeartbeatInterval            time.Duration                                     `mapstructure:"pool-heartbeat-interval" json:"pool_heartbeat_interval,omitempty"` // Interval for connection pool heartbeat in seconds
 	PoolHeartbeatTimeout             time.Duration                                     `mapstructure:"pool-heartbeat-timeout" json:"pool_heartbeat_timeout,omitempty"`   // Timeout for connection pool heartbeat in seconds
@@ -222,6 +223,7 @@ func NewDump() Dump {
 				MaxAllowedPacket: DefaultMaxAllowedPacket,
 			},
 			DumpFormat: commonmodels.DumpFormatInsert,
+			HexBlob:    true,
 		},
 		Options: CommonDumpOptions{
 			Compress: true,

--- a/pkg/mysql/cmdrun/dump/dump.go
+++ b/pkg/mysql/cmdrun/dump/dump.go
@@ -435,6 +435,9 @@ func (d *Dump) DataDump(ctx context.Context) (err error) {
 		taskProducerOpts = append(taskProducerOpts, taskproducer.WithTransformedTablesOnly())
 	}
 	taskProducerOpts = append(taskProducerOpts, taskproducer.WithDumpFormat(d.format))
+	if d.cfg.Dump.MysqlConfig.HexBlob {
+		taskProducerOpts = append(taskProducerOpts, taskproducer.WithHexBlob())
+	}
 
 	tp, err := taskproducer.New(
 		d.introsp,

--- a/pkg/mysql/dump/streamers/insert_writer.go
+++ b/pkg/mysql/dump/streamers/insert_writer.go
@@ -26,6 +26,8 @@ import (
 	"github.com/greenmaskio/greenmask/pkg/mysql/dbmsdriver"
 )
 
+const hexChars = "0123456789ABCDEF"
+
 // InsertWriter writes one value tuple per line:
 //
 //	(val1,val2,val3)
@@ -35,42 +37,71 @@ import (
 // The INSERT statement is assembled on the restore side, allowing the conflict
 // resolution strategy (INSERT / INSERT IGNORE / REPLACE) and batch size to be
 // chosen at restore time.
+//
+// When hexBlob is true, columns of binary/blob types are emitted as X'...' hex
+// literals instead of escaped string literals, making the dump charset-independent
+// and safe for arbitrary byte values.
 type InsertWriter struct {
-	table       *models.Table
-	w           io.Writer
-	vals        []interface{}
-	rowTemplate string
+	table      *models.Table
+	w          io.Writer
+	isBinary   []bool // pre-computed: true for BINARY/VARBINARY/BLOB family columns
+	hasHexCols bool   // true when any column in isBinary is set
+	sb         strings.Builder
 }
 
-func NewInsertWriter(table models.Table, w io.Writer) *InsertWriter {
-	placeholders := make([]string, len(table.Columns))
-	for i := range table.Columns {
-		placeholders[i] = "?"
+func NewInsertWriter(table models.Table, w io.Writer, hexBlob bool) *InsertWriter {
+	isBinary := make([]bool, len(table.Columns))
+	hasHexCols := false
+	for i, col := range table.Columns {
+		if hexBlob && isBinaryType(col) {
+			isBinary[i] = true
+			hasHexCols = true
+		}
 	}
-	rowTemplate := "(" + strings.Join(placeholders, ", ") + ")"
 	return &InsertWriter{
-		table:       &table,
-		w:           w,
-		vals:        make([]interface{}, len(table.Columns)),
-		rowTemplate: rowTemplate,
+		table:      &table,
+		w:          w,
+		isBinary:   isBinary,
+		hasHexCols: hasHexCols,
 	}
+}
+
+// isBinaryType reports whether the column belongs to the binary/blob type class.
+// TypeClass is used rather than TypeName because MySQL reports COLUMN_TYPE as
+// "binary(16)" or "varbinary(255)" (with length suffix), which does not match
+// the bare type-name constants. TypeClass is always resolved correctly via the
+// DATA_TYPE fallback in the introspector.
+func isBinaryType(col models.Column) bool {
+	return col.TypeClass == models.TypeClassBinary
 }
 
 func (iw *InsertWriter) Write(row [][]byte) error {
+	iw.sb.Reset()
+	iw.sb.WriteByte('(')
 	for i, val := range row {
-		if bytes.Equal(val, dbmsdriver.NullValueSeq) {
-			iw.vals[i] = nil
-		} else {
-			iw.vals[i] = string(val)
+		if i > 0 {
+			iw.sb.WriteString(", ")
+		}
+		switch {
+		case bytes.Equal(val, dbmsdriver.NullValueSeq):
+			iw.sb.WriteString("NULL")
+		case iw.hasHexCols && iw.isBinary[i]:
+			iw.sb.WriteString("X'")
+			for _, b := range val {
+				iw.sb.WriteByte(hexChars[b>>4])
+				iw.sb.WriteByte(hexChars[b&0x0f])
+			}
+			iw.sb.WriteByte('\'')
+		default:
+			s, err := sqlbuilder.MySQL.Interpolate("?", []interface{}{string(val)})
+			if err != nil {
+				return fmt.Errorf("interpolate col %d: %w", i, err)
+			}
+			iw.sb.WriteString(s)
 		}
 	}
-
-	interpolated, err := sqlbuilder.MySQL.Interpolate(iw.rowTemplate, iw.vals)
-	if err != nil {
-		return fmt.Errorf("interpolate row: %w", err)
-	}
-
-	if _, err := fmt.Fprintf(iw.w, "%s\n", interpolated); err != nil {
+	iw.sb.WriteString(")\n")
+	if _, err := fmt.Fprint(iw.w, iw.sb.String()); err != nil {
 		return fmt.Errorf("write row: %w", err)
 	}
 	return nil

--- a/pkg/mysql/dump/streamers/insert_writer_test.go
+++ b/pkg/mysql/dump/streamers/insert_writer_test.go
@@ -25,7 +25,7 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf)
+		iw := NewInsertWriter(table, &buf, false)
 
 		row := [][]byte{[]byte("1"), []byte("John Doe"), []byte("john@example.com")}
 		err := iw.Write(row)
@@ -46,7 +46,7 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf)
+		iw := NewInsertWriter(table, &buf, false)
 
 		err := iw.Write([][]byte{[]byte("1"), []byte("John Doe")})
 		assert.NoError(t, err)
@@ -69,7 +69,7 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf)
+		iw := NewInsertWriter(table, &buf, false)
 
 		row := [][]byte{[]byte("1"), dbmsdriver.NullValueSeq}
 		err := iw.Write(row)
@@ -89,7 +89,7 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf)
+		iw := NewInsertWriter(table, &buf, false)
 
 		rr := rawrecord.NewRawRecord(2, dbmsdriver.NullValueSeq)
 		err := rr.SetColumn(0, models.NewColumnRawValue([]byte("1"), false))
@@ -114,10 +114,124 @@ func TestInsertWriter_Write(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		iw := NewInsertWriter(table, &buf)
+		iw := NewInsertWriter(table, &buf, false)
 
 		err := iw.Flush()
 		assert.NoError(t, err)
 		assert.Empty(t, buf.String())
+	})
+}
+
+func TestInsertWriter_HexBlob(t *testing.T) {
+	// binaryCol mirrors what the introspector produces: TypeName may include a length
+	// suffix (e.g. "binary(16)"), so TypeClass is the reliable signal.
+	binaryCol := func(typeName string) models.Column {
+		return models.Column{Name: "data", TypeName: typeName, TypeClass: models.TypeClassBinary}
+	}
+
+	binaryTypes := []string{
+		"binary(16)", // COLUMN_TYPE form with length suffix
+		"varbinary(255)",
+		dbmsdriver.TypeTinyBlob,
+		dbmsdriver.TypeBlob,
+		dbmsdriver.TypeMediumBlob,
+		dbmsdriver.TypeLongBlob,
+	}
+
+	t.Run("all_binary_types_produce_hex_literal", func(t *testing.T) {
+		for _, typeName := range binaryTypes {
+			var buf bytes.Buffer
+			table := models.Table{
+				Name:    "t",
+				Columns: []models.Column{binaryCol(typeName)},
+			}
+			iw := NewInsertWriter(table, &buf, true)
+			err := iw.Write([][]byte{{0xDE, 0xAD, 0xBE, 0xEF}})
+			assert.NoError(t, err, "type %s", typeName)
+			assert.Equal(t, "(X'DEADBEEF')\n", buf.String(), "type %s", typeName)
+		}
+	})
+
+	t.Run("high_bytes_invalid_utf8", func(t *testing.T) {
+		table := models.Table{
+			Name:    "t",
+			Columns: []models.Column{binaryCol(dbmsdriver.TypeBlob)},
+		}
+		var buf bytes.Buffer
+		iw := NewInsertWriter(table, &buf, true)
+		// Bytes > 0x7F that are invalid utf8mb4 sequences — unsafe without hex-blob.
+		err := iw.Write([][]byte{{0x80, 0x81, 0xFE, 0xFF}})
+		assert.NoError(t, err)
+		assert.Equal(t, "(X'8081FEFF')\n", buf.String())
+	})
+
+	t.Run("null_byte_and_escape_chars", func(t *testing.T) {
+		table := models.Table{
+			Name:    "t",
+			Columns: []models.Column{binaryCol(dbmsdriver.TypeVarBinary)},
+		}
+		var buf bytes.Buffer
+		iw := NewInsertWriter(table, &buf, true)
+		// \x00 \x0A \x0D \x5C \x27 — bytes that need escaping in plain string literals.
+		err := iw.Write([][]byte{{0x00, 0x0A, 0x0D, 0x5C, 0x27}})
+		assert.NoError(t, err)
+		assert.Equal(t, "(X'000A0D5C27')\n", buf.String())
+	})
+
+	t.Run("null_binary_value", func(t *testing.T) {
+		table := models.Table{
+			Name:    "t",
+			Columns: []models.Column{binaryCol(dbmsdriver.TypeBlob)},
+		}
+		var buf bytes.Buffer
+		iw := NewInsertWriter(table, &buf, true)
+		err := iw.Write([][]byte{dbmsdriver.NullValueSeq})
+		assert.NoError(t, err)
+		assert.Equal(t, "(NULL)\n", buf.String())
+	})
+
+	t.Run("empty_binary_value", func(t *testing.T) {
+		table := models.Table{
+			Name:    "t",
+			Columns: []models.Column{binaryCol(dbmsdriver.TypeBlob)},
+		}
+		var buf bytes.Buffer
+		iw := NewInsertWriter(table, &buf, true)
+		err := iw.Write([][]byte{{}})
+		assert.NoError(t, err)
+		assert.Equal(t, "(X'')\n", buf.String())
+	})
+
+	t.Run("mixed_binary_and_text_columns", func(t *testing.T) {
+		table := models.Table{
+			Name: "t",
+			Columns: []models.Column{
+				{Name: "id", TypeName: dbmsdriver.TypeInt, TypeClass: models.TypeClassInt},
+				{Name: "name", TypeName: dbmsdriver.TypeVarChar, TypeClass: models.TypeClassText},
+				{Name: "data", TypeName: dbmsdriver.TypeBlob, TypeClass: models.TypeClassBinary},
+			},
+		}
+		var buf bytes.Buffer
+		iw := NewInsertWriter(table, &buf, true)
+		err := iw.Write([][]byte{
+			[]byte("42"),
+			[]byte("hello"),
+			{0xCA, 0xFE, 0xBA, 0xBE},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "('42', 'hello', X'CAFEBABE')\n", buf.String())
+	})
+
+	t.Run("hex_blob_disabled_binary_col_is_string", func(t *testing.T) {
+		table := models.Table{
+			Name:    "t",
+			Columns: []models.Column{binaryCol(dbmsdriver.TypeBlob)},
+		}
+		var buf bytes.Buffer
+		iw := NewInsertWriter(table, &buf, false)
+		// With hex-blob off, binary data goes through the string/escape path.
+		err := iw.Write([][]byte{{'A', 'B', 'C'}})
+		assert.NoError(t, err)
+		assert.Equal(t, "('ABC')\n", buf.String())
 	})
 }

--- a/pkg/mysql/dump/streamers/table_data_writer.go
+++ b/pkg/mysql/dump/streamers/table_data_writer.go
@@ -51,6 +51,7 @@ type TableDataWriter struct {
 	enabled   bool
 	pgzip     bool
 	format    models.DumpFormat
+	hexBlob   bool
 }
 
 func NewTableDataWriter(
@@ -99,6 +100,12 @@ func WithPgzip(enabled bool) Option {
 	}
 }
 
+func WithHexBlob(enabled bool) Option {
+	return func(t *TableDataWriter) {
+		t.hexBlob = enabled
+	}
+}
+
 func (t *TableDataWriter) steam(ctx context.Context) func() error {
 	return func() error {
 		if err := t.st.PutObject(ctx, t.fileName, t.cr); err != nil {
@@ -116,7 +123,7 @@ func (t *TableDataWriter) Open(ctx context.Context) error {
 	}
 
 	if t.format == models.DumpFormatInsert {
-		t.rowWriter = NewInsertWriter(*t.table, t.cw)
+		t.rowWriter = NewInsertWriter(*t.table, t.cw, t.hexBlob)
 	} else {
 		t.rowWriter = csv.NewWriter(t.cw)
 	}

--- a/pkg/mysql/dump/taskproducer/task_producer.go
+++ b/pkg/mysql/dump/taskproducer/task_producer.go
@@ -62,6 +62,7 @@ type TaskProducer struct {
 	compressionPgzip      bool
 	transformedTablesOnly bool
 	dumpFormat            models.DumpFormat
+	hexBlob               bool
 }
 
 func WithFilter(
@@ -116,6 +117,13 @@ func WithDumpFormat(format models.DumpFormat) Option {
 		if format != "" {
 			tp.dumpFormat = format
 		}
+		return nil
+	}
+}
+
+func WithHexBlob() Option {
+	return func(tp *TaskProducer) error {
+		tp.hexBlob = true
 		return nil
 	}
 }
@@ -199,6 +207,7 @@ func (tp *TaskProducer) initTableDumper(
 		dumpstreamers.WithCompression(tp.compressionEnabled),
 		dumpstreamers.WithPgzip(tp.compressionPgzip),
 		dumpstreamers.WithFormat(tp.dumpFormat),
+		dumpstreamers.WithHexBlob(tp.hexBlob),
 	)
 	rawRecord := rawrecord.NewRawRecord(len(tableContext.Table.Columns), dbmsdriver.NullValueSeq)
 	r := record.NewRecord(rawRecord, tableContext.TableDriver)
@@ -226,6 +235,7 @@ func (tp *TaskProducer) initTableRawDumper(
 		dumpstreamers.WithCompression(tp.compressionEnabled),
 		dumpstreamers.WithPgzip(tp.compressionPgzip),
 		dumpstreamers.WithFormat(tp.dumpFormat),
+		dumpstreamers.WithHexBlob(tp.hexBlob),
 	)
 	return dumpers.NewTableRawDumper(objectID, tr, tw, tableContext.Table)
 }

--- a/playground/mysql/config-local.yaml
+++ b/playground/mysql/config-local.yaml
@@ -58,8 +58,8 @@ dump:
     port: 3306
     #    add-drop-table: false
     dump-format: insert
-    #      insert-batch-size: 100000000
-    vendor-options: [ ]
+    hex-blob: true
+    vendor-options: [ "--opt" ]
 
   transformation:
     - schema: employees
@@ -88,14 +88,13 @@ dump:
 restore:
   options:
     jobs: 10
-    schema-only: true
-#    create-database: true
-#    if-not-exists: true
+    create-database: true
+    if-not-exists: true
 #    section:
 #      - pre-data
 #      - post-data
 #      - data
-#    restore-in-order: true
+    restore-in-order: true
 
   mysql:
     user: root

--- a/tests/integration/features/dump/hex_blob_test.go
+++ b/tests/integration/features/dump/hex_blob_test.go
@@ -1,0 +1,342 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dump
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/greenmaskio/greenmask/pkg/common/transformers/registry"
+	"github.com/greenmaskio/greenmask/pkg/common/utils"
+	"github.com/greenmaskio/greenmask/pkg/common/validationcollector"
+	"github.com/greenmaskio/greenmask/pkg/config"
+	"github.com/greenmaskio/greenmask/pkg/mysql/cmdrun/dump"
+	"github.com/greenmaskio/greenmask/pkg/storages/validate"
+	"github.com/greenmaskio/greenmask/pkg/testutils"
+)
+
+var (
+	hexBlobMigrationUp = []string{
+		`CREATE TABLE hex_blob_test (
+			id            INT AUTO_INCREMENT PRIMARY KEY,
+			col_binary    BINARY(16),
+			col_varbinary VARBINARY(255),
+			col_tinyblob  TINYBLOB,
+			col_blob      BLOB,
+			col_medblob   MEDIUMBLOB,
+			col_longblob  LONGBLOB
+		)`,
+		// Row 1: null bytes and low control bytes (invisible without hex-blob)
+		`INSERT INTO hex_blob_test (col_binary, col_varbinary, col_tinyblob, col_blob, col_medblob, col_longblob)
+		 VALUES (
+			UNHEX('00000000000000000000000000000000'),
+			UNHEX('0001020304'),
+			UNHEX('00'),
+			UNHEX('DEADBEEF'),
+			UNHEX('CAFEBABE0102030405'),
+			UNHEX('FFFEFDFCFBFA')
+		 )`,
+		// Row 2: high bytes invalid under utf8mb4 — corrupt without hex-blob
+		`INSERT INTO hex_blob_test (col_binary, col_varbinary, col_tinyblob, col_blob, col_medblob, col_longblob)
+		 VALUES (
+			UNHEX('DEADBEEFDEADBEEFDEADBEEFDEADBEEF'),
+			UNHEX('80818283848586878889'),
+			UNHEX('F0F1F2F3'),
+			UNHEX('C0C1FEFF'),
+			UNHEX('E0E1E2E3E4E5'),
+			UNHEX('F8F9FAFBFCFDFEFF')
+		 )`,
+		// Row 3: bytes that need escaping in plain string literals
+		`INSERT INTO hex_blob_test (col_binary, col_varbinary, col_tinyblob, col_blob, col_medblob, col_longblob)
+		 VALUES (
+			UNHEX('00000000000000000000000000000000'),
+			UNHEX('0A0D5C27'),
+			UNHEX('1A'),
+			UNHEX('22'),
+			UNHEX('0000000000'),
+			UNHEX('AABBCCDDEE')
+		 )`,
+	}
+
+	hexBlobMigrationDown = []string{
+		`DROP TABLE hex_blob_test`,
+	}
+)
+
+type hexBlobDumpSuite struct {
+	testutils.MySQLContainerSuite
+}
+
+func (s *hexBlobDumpSuite) SetupSuite() {
+	s.MySQLContainerSuite.SetImage(mysqlImage).
+		SetMigrationUp(append(migrationUpTable, append(migrationUpData, hexBlobMigrationUp...)...)).
+		SetMigrationDown(append(migrationDown, hexBlobMigrationDown...)).
+		SetupSuite()
+}
+
+func (s *hexBlobDumpSuite) setupInfrastructure(ctx context.Context) context.Context {
+	ctx = log.Ctx(ctx).With().Str(commonmodels.MetaKeyEngine, "mysql").Logger().WithContext(ctx)
+	vc := validationcollector.NewCollectorWithMeta(commonmodels.MetaKeyEngine, "mysql")
+	ctx = validationcollector.WithCollector(ctx, vc)
+	s.Require().NoError(utils.SetDefaultContextLogger("debug", "text"))
+	return ctx
+}
+
+func (s *hexBlobDumpSuite) getBaseConfig(ctx context.Context) *config.Config {
+	cfg := config.NewConfig()
+	cfg.Engine = "mysql"
+	cfg.Log.Level = "debug"
+	cfg.Log.Format = "text"
+
+	connOpts := s.GetRootConnectionOpts(ctx)
+	cfg.Dump.MysqlConfig.Host = connOpts.Host
+	cfg.Dump.MysqlConfig.Port = connOpts.Port
+	cfg.Dump.MysqlConfig.User = connOpts.User
+	cfg.Dump.MysqlConfig.Password = connOpts.Password
+	cfg.Dump.MysqlConfig.ConnectDatabase = "testdb"
+	cfg.Dump.Options.DataOnly = false
+	cfg.Dump.Options.SchemaOnly = false
+	cfg.Dump.Options.IncludeTable = nil
+	cfg.Dump.Options.ExcludeTable = nil
+	cfg.Dump.Options.IncludeSchema = nil
+	cfg.Dump.Options.ExcludeSchema = nil
+	cfg.Dump.Options.IncludeDatabase = nil
+	cfg.Dump.Options.ExcludeDatabase = nil
+	cfg.Dump.Options.ExcludeTableData = nil
+	cfg.Dump.Options.IncludeTableData = nil
+	cfg.Dump.Options.IncludeTableDefinition = nil
+	cfg.Dump.Options.ExcludeTableDefinition = nil
+	cfg.Dump.MysqlConfig.VendorOptions = nil
+	cfg.Dump.Options.Compress = false
+	cfg.Dump.Options.Pgzip = false
+	return cfg
+}
+
+func (s *hexBlobDumpSuite) TestHexBlobDump() {
+	ctx := context.Background()
+
+	s.Run("hex_blob_enabled_all_binary_cols_encoded", func() {
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.Options.IncludeTable = []string{"testdb.hex_blob_test"}
+		cfg.Dump.MysqlConfig.HexBlob = true
+
+		st := validate.New("")
+		defer st.Cleanup()
+
+		cmdRunner := &CmdRunnerMock{}
+		cmdRunner.On("ExecuteCmdAndWriteStdout", mock.Anything, mock.Anything).
+			Return(nil).
+			Run(func(args mock.Arguments) {
+				w := args.Get(1).(io.Writer)
+				_, err := w.Write([]byte("-- mock schema"))
+				s.Require().NoError(err)
+			})
+		cmdProducer := &CmdProducerMock{}
+		cmdProducer.On("Produce", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(cmdRunner, nil)
+
+		dumpProcess, err := dump.NewDump(cfg, registry.DefaultTransformerRegistry, st, cmdProducer, dump.GetMySQLDumpOpts(cfg)...)
+		s.Require().NoError(err)
+		s.Require().NoError(dumpProcess.Run(ctx))
+
+		// Read the dumped file from in-memory storage.
+		rc, err := st.GetObject(ctx, "testdb__hex_blob_test.sql")
+		s.Require().NoError(err)
+		defer rc.Close()
+
+		content, err := io.ReadAll(rc)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(content)
+
+		lines := splitNonEmpty(string(content))
+		s.Require().Len(lines, 3, "expected 3 data rows")
+
+		// Every binary column value (positions 1-6, 0-indexed after the id) must be
+		// an X'...' hex literal — no raw bytes or escaped string literals.
+		for i, line := range lines {
+			cols := parseTupleCols(line)
+			s.Require().Len(cols, 7, "row %d: expected 7 columns", i+1)
+			// col_binary (BINARY(16)) — previously produced raw escaped bytes
+			s.assertHexLiteral(cols[1], "row %d col_binary", i+1)
+			// col_varbinary (VARBINARY(255)) — previously produced raw escaped bytes
+			s.assertHexLiteral(cols[2], "row %d col_varbinary", i+1)
+			// blob family — these already worked before the fix
+			s.assertHexLiteral(cols[3], "row %d col_tinyblob", i+1)
+			s.assertHexLiteral(cols[4], "row %d col_blob", i+1)
+			s.assertHexLiteral(cols[5], "row %d col_medblob", i+1)
+			s.assertHexLiteral(cols[6], "row %d col_longblob", i+1)
+		}
+
+		// Verify exact hex values for the known test rows.
+		row1 := parseTupleCols(lines[0])
+		s.Equal("X'00000000000000000000000000000000'", row1[1])
+		s.Equal("X'0001020304'", row1[2])
+		s.Equal("X'00'", row1[3])
+		s.Equal("X'DEADBEEF'", row1[4])
+		s.Equal("X'CAFEBABE0102030405'", row1[5])
+		s.Equal("X'FFFEFDFCFBFA'", row1[6])
+
+		row2 := parseTupleCols(lines[1])
+		s.Equal("X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'", row2[1])
+		s.Equal("X'80818283848586878889'", row2[2])
+
+		row3 := parseTupleCols(lines[2])
+		// \n \r \ ' — bytes that require escaping in a plain string literal
+		s.Equal("X'0A0D5C27'", row3[2])
+		s.Equal("X'1A'", row3[3]) // Ctrl-Z
+		s.Equal("X'22'", row3[4]) // double-quote
+
+		cmdProducer.AssertExpectations(s.T())
+		cmdRunner.AssertExpectations(s.T())
+	})
+
+	s.Run("hex_blob_disabled_binary_cols_not_hex", func() {
+		ctx := s.setupInfrastructure(ctx)
+		cfg := s.getBaseConfig(ctx)
+		cfg.Dump.Options.IncludeSchema = []string{"testdb"}
+		cfg.Dump.Options.IncludeTable = []string{"testdb.hex_blob_test"}
+		cfg.Dump.MysqlConfig.HexBlob = false
+
+		st := validate.New("")
+		defer st.Cleanup()
+
+		cmdRunner := &CmdRunnerMock{}
+		cmdRunner.On("ExecuteCmdAndWriteStdout", mock.Anything, mock.Anything).
+			Return(nil).
+			Run(func(args mock.Arguments) {
+				w := args.Get(1).(io.Writer)
+				_, err := w.Write([]byte("-- mock schema"))
+				s.Require().NoError(err)
+			})
+		cmdProducer := &CmdProducerMock{}
+		cmdProducer.On("Produce", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(cmdRunner, nil)
+
+		dumpProcess, err := dump.NewDump(cfg, registry.DefaultTransformerRegistry, st, cmdProducer, dump.GetMySQLDumpOpts(cfg)...)
+		s.Require().NoError(err)
+		s.Require().NoError(dumpProcess.Run(ctx))
+
+		rc, err := st.GetObject(ctx, "testdb__hex_blob_test.sql")
+		s.Require().NoError(err)
+		defer rc.Close()
+
+		content, err := io.ReadAll(rc)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(content)
+
+		lines := splitNonEmpty(string(content))
+		s.Require().Len(lines, 3)
+
+		// With hex-blob off, NO column should be an X'...' hex literal —
+		// everything goes through the string/escape path.
+		for i, line := range lines {
+			s.NotContains(line, "X'", "row %d should not contain X' hex literals when hex-blob is disabled", i+1)
+		}
+
+		cmdProducer.AssertExpectations(s.T())
+		cmdRunner.AssertExpectations(s.T())
+	})
+}
+
+// assertHexLiteral asserts that val is an X'...' hex literal.
+func (s *hexBlobDumpSuite) assertHexLiteral(val, msgFmt string, args ...any) {
+	s.Truef(
+		strings.HasPrefix(val, "X'") && strings.HasSuffix(val, "'"),
+		msgFmt+" = %q: expected X'...' hex literal", append(args, val)...,
+	)
+}
+
+// splitNonEmpty splits content by newlines and returns non-empty lines.
+func splitNonEmpty(content string) []string {
+	var lines []string
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		if line := strings.TrimSpace(scanner.Text()); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// parseTupleCols splits a dump tuple "(v1, v2, v3)" into its column values.
+// It handles X'...' literals, 'string' literals, and unquoted values (NULL, numbers).
+// This is a best-effort parser sufficient for the known test data shapes.
+func parseTupleCols(line string) []string {
+	// Strip outer parens.
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "(")
+	line = strings.TrimSuffix(line, ")")
+
+	var cols []string
+	i := 0
+	for i < len(line) {
+		// Skip leading whitespace / comma separator.
+		for i < len(line) && (line[i] == ' ' || line[i] == ',') {
+			i++
+		}
+		if i >= len(line) {
+			break
+		}
+
+		if line[i] == 'X' && i+1 < len(line) && line[i+1] == '\'' {
+			// X'...' hex literal — find the closing single-quote.
+			end := strings.Index(line[i+2:], "'")
+			if end < 0 {
+				break
+			}
+			cols = append(cols, line[i:i+2+end+1])
+			i += 2 + end + 1
+		} else if line[i] == '\'' {
+			// 'string' literal — scan until unescaped closing quote.
+			j := i + 1
+			for j < len(line) {
+				if line[j] == '\\' {
+					j += 2
+					continue
+				}
+				if line[j] == '\'' {
+					break
+				}
+				j++
+			}
+			cols = append(cols, line[i:j+1])
+			i = j + 1
+		} else {
+			// Unquoted token (NULL, number).
+			end := strings.IndexAny(line[i:], ", ")
+			if end < 0 {
+				cols = append(cols, line[i:])
+				break
+			}
+			cols = append(cols, line[i:i+end])
+			i += end
+		}
+	}
+	return cols
+}
+
+func TestHexBlobDumpSuite(t *testing.T) {
+	suite.Run(t, new(hexBlobDumpSuite))
+}

--- a/tests/integration/features/dump/hex_blob_test.go
+++ b/tests/integration/features/dump/hex_blob_test.go
@@ -135,6 +135,12 @@ func (s *hexBlobDumpSuite) getBaseConfig(ctx context.Context) *config.Config {
 func (s *hexBlobDumpSuite) TestHexBlobDump() {
 	ctx := context.Background()
 
+	const (
+		hexRow1 = `('1', X'00000000000000000000000000000000', X'0001020304', X'00', X'DEADBEEF', X'CAFEBABE0102030405', X'FFFEFDFCFBFA')`
+		hexRow2 = `('2', X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF', X'80818283848586878889', X'F0F1F2F3', X'C0C1FEFF', X'E0E1E2E3E4E5', X'F8F9FAFBFCFDFEFF')`
+		hexRow3 = `('3', X'00000000000000000000000000000000', X'0A0D5C27', X'1A', X'22', X'0000000000', X'AABBCCDDEE')`
+	)
+
 	s.Run("hex_blob_enabled_all_binary_cols_encoded", func() {
 		ctx := s.setupInfrastructure(ctx)
 		cfg := s.getBaseConfig(ctx)
@@ -161,52 +167,18 @@ func (s *hexBlobDumpSuite) TestHexBlobDump() {
 		s.Require().NoError(err)
 		s.Require().NoError(dumpProcess.Run(ctx))
 
-		// Read the dumped file from in-memory storage.
 		rc, err := st.GetObject(ctx, "testdb__hex_blob_test.sql")
 		s.Require().NoError(err)
 		defer rc.Close()
 
 		content, err := io.ReadAll(rc)
 		s.Require().NoError(err)
-		s.Require().NotEmpty(content)
 
 		lines := splitNonEmpty(string(content))
 		s.Require().Len(lines, 3, "expected 3 data rows")
-
-		// Every binary column value (positions 1-6, 0-indexed after the id) must be
-		// an X'...' hex literal — no raw bytes or escaped string literals.
-		for i, line := range lines {
-			cols := parseTupleCols(line)
-			s.Require().Len(cols, 7, "row %d: expected 7 columns", i+1)
-			// col_binary (BINARY(16)) — previously produced raw escaped bytes
-			s.assertHexLiteral(cols[1], "row %d col_binary", i+1)
-			// col_varbinary (VARBINARY(255)) — previously produced raw escaped bytes
-			s.assertHexLiteral(cols[2], "row %d col_varbinary", i+1)
-			// blob family — these already worked before the fix
-			s.assertHexLiteral(cols[3], "row %d col_tinyblob", i+1)
-			s.assertHexLiteral(cols[4], "row %d col_blob", i+1)
-			s.assertHexLiteral(cols[5], "row %d col_medblob", i+1)
-			s.assertHexLiteral(cols[6], "row %d col_longblob", i+1)
-		}
-
-		// Verify exact hex values for the known test rows.
-		row1 := parseTupleCols(lines[0])
-		s.Equal("X'00000000000000000000000000000000'", row1[1])
-		s.Equal("X'0001020304'", row1[2])
-		s.Equal("X'00'", row1[3])
-		s.Equal("X'DEADBEEF'", row1[4])
-		s.Equal("X'CAFEBABE0102030405'", row1[5])
-		s.Equal("X'FFFEFDFCFBFA'", row1[6])
-
-		row2 := parseTupleCols(lines[1])
-		s.Equal("X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'", row2[1])
-		s.Equal("X'80818283848586878889'", row2[2])
-
-		row3 := parseTupleCols(lines[2])
-		// \n \r \ ' — bytes that require escaping in a plain string literal
-		s.Equal("X'0A0D5C27'", row3[2])
-		s.Equal("X'1A'", row3[3]) // Ctrl-Z
-		s.Equal("X'22'", row3[4]) // double-quote
+		s.Equal(hexRow1, lines[0])
+		s.Equal(hexRow2, lines[1])
+		s.Equal(hexRow3, lines[2])
 
 		cmdProducer.AssertExpectations(s.T())
 		cmdRunner.AssertExpectations(s.T())
@@ -260,14 +232,6 @@ func (s *hexBlobDumpSuite) TestHexBlobDump() {
 	})
 }
 
-// assertHexLiteral asserts that val is an X'...' hex literal.
-func (s *hexBlobDumpSuite) assertHexLiteral(val, msgFmt string, args ...any) {
-	s.Truef(
-		strings.HasPrefix(val, "X'") && strings.HasSuffix(val, "'"),
-		msgFmt+" = %q: expected X'...' hex literal", append(args, val)...,
-	)
-}
-
 // splitNonEmpty splits content by newlines and returns non-empty lines.
 func splitNonEmpty(content string) []string {
 	var lines []string
@@ -278,63 +242,6 @@ func splitNonEmpty(content string) []string {
 		}
 	}
 	return lines
-}
-
-// parseTupleCols splits a dump tuple "(v1, v2, v3)" into its column values.
-// It handles X'...' literals, 'string' literals, and unquoted values (NULL, numbers).
-// This is a best-effort parser sufficient for the known test data shapes.
-func parseTupleCols(line string) []string {
-	// Strip outer parens.
-	line = strings.TrimSpace(line)
-	line = strings.TrimPrefix(line, "(")
-	line = strings.TrimSuffix(line, ")")
-
-	var cols []string
-	i := 0
-	for i < len(line) {
-		// Skip leading whitespace / comma separator.
-		for i < len(line) && (line[i] == ' ' || line[i] == ',') {
-			i++
-		}
-		if i >= len(line) {
-			break
-		}
-
-		if line[i] == 'X' && i+1 < len(line) && line[i+1] == '\'' {
-			// X'...' hex literal — find the closing single-quote.
-			end := strings.Index(line[i+2:], "'")
-			if end < 0 {
-				break
-			}
-			cols = append(cols, line[i:i+2+end+1])
-			i += 2 + end + 1
-		} else if line[i] == '\'' {
-			// 'string' literal — scan until unescaped closing quote.
-			j := i + 1
-			for j < len(line) {
-				if line[j] == '\\' {
-					j += 2
-					continue
-				}
-				if line[j] == '\'' {
-					break
-				}
-				j++
-			}
-			cols = append(cols, line[i:j+1])
-			i = j + 1
-		} else {
-			// Unquoted token (NULL, number).
-			end := strings.IndexAny(line[i:], ", ")
-			if end < 0 {
-				cols = append(cols, line[i:])
-				break
-			}
-			cols = append(cols, line[i:i+end])
-			i += end
-		}
-	}
-	return cols
 }
 
 func TestHexBlobDumpSuite(t *testing.T) {


### PR DESCRIPTION
Encode binary columns as X'...' hex literals in INSERT dumps when hex_blob is enabled (default: true), preventing data corruption for null bytes, high bytes invalid under utf8mb4, and characters that require escaping in plain string literals.                                                                                                                                                            
                                                                                                                                                                                                         
- Add HexBlob bool field to MysqlDumpConfig; default true in NewDump()
- InsertWriter: pre-compute isBinary[] per column using TypeClass; merged writeHex/writeInterpolated into single Write method using hasHexCols && isBinary[i] guard; reuses struct-level strings.Builder across rows             
- Wire WithHexBlob option through TableDataWriter → taskproducer → Dump.DataDump
- Integration tests: decouple hexBlobDumpSuite from dumpTestSuite by embedding testutils.MySQLContainerSuite directly                                                                                 

Increment for #222 