### PR TITLE
fix(pgcopy): return clear error when row has more columns than tuple size

### DIFF
--- a/internal/db/postgres/pgcopy/row.go
+++ b/internal/db/postgres/pgcopy/row.go
@@ -16,6 +16,7 @@ package pgcopy
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/greenmaskio/greenmask/pkg/toolkit"
@@ -98,6 +99,14 @@ func (r *Row) Decode(raw []byte) error {
 		}
 		if r.isDynamic && idx >= r.tupleSize {
 			r.appendNewEmptyBuffer()
+		}
+
+		// A static-tuple row that receives a stream with more columns
+		// than the table (e.g. a user `query:` that joins extra columns)
+		// would otherwise panic here with 'index out of range' inside
+		// the dump pipeline. Return a clear error instead.
+		if idx >= len(r.columnPos) {
+			return fmt.Errorf("pgcopy: row has more columns than the configured tuple size (%d); check that the transformation's `query:` does not select additional columns", r.tupleSize)
 		}
 
 		p := r.columnPos[idx]


### PR DESCRIPTION
Fixes GreenmaskIO/greenmask#432.

## Problem

`Row.Decode` assumed the delimited columns in the raw COPY stream matched `tupleSize`. A transformation with a user `query:` that returns additional columns (for join/lookup use cases) exceeded `len(r.columnPos)` in the static branch, and `r.columnPos[idx]` panicked the dump pipeline:

```
panic: runtime error: index out of range [5] with length 5
internal/db/postgres/pgcopy.(*Row).Decode row.go:103
internal/db/postgres/dumpers.(*TransformationPipeline).Dump transformation_pipeline.go:160
```

## Fix

Return a descriptive error naming `tupleSize` so operators see an actionable message instead of a hard panic. The `isDynamic` path is unchanged.

## Test

`go test ./internal/db/postgres/pgcopy/...` passes locally.