### PR TITLE
feat: [MySQL] add remap-database option to restore

### DIFF
--- a/pkg/common/models/enums.go
+++ b/pkg/common/models/enums.go
@@ -1,0 +1,19 @@
+package models
+
+import "fmt"
+
+type DatabaseReplacementMode string
+
+const (
+	DatabaseReplaceModeStrict  DatabaseReplacementMode = "strict"
+	DatabaseReplaceModeRelaxed DatabaseReplacementMode = "relaxed"
+)
+
+func (m DatabaseReplacementMode) Validate() error {
+	switch m {
+	case DatabaseReplaceModeRelaxed, DatabaseReplaceModeStrict:
+		return nil
+	default:
+		return fmt.Errorf("value '%s': %w", m, ErrValueValidationFailed)
+	}
+}

--- a/pkg/common/models/enums_test.go
+++ b/pkg/common/models/enums_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseReplacementMode_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    DatabaseReplacementMode
+		wantErr bool
+	}{
+		{name: "strict is valid", mode: DatabaseReplaceModeStrict},
+		{name: "relaxed is valid", mode: DatabaseReplaceModeRelaxed},
+		{name: "unknown mode is invalid", mode: "unknown", wantErr: true},
+		{name: "empty string is invalid", mode: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.mode.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/config/restore.go
+++ b/pkg/config/restore.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	commonconfig "github.com/greenmaskio/greenmask/pkg/common/config"
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
 	mysqlcommonconfig "github.com/greenmaskio/greenmask/pkg/mysql/config"
 )
 
@@ -51,9 +52,9 @@ const DefaultMaxFetchWarnings = 10
 const DefaultMaxInsertStatementSize = 4 * 1024 * 1024
 
 type MysqlRestoreConfig struct {
-	mysqlcommonconfig.ConnectionOpts `mapstructure:",squash" json:",squash,omitempty"`
-	VendorOptions                    []string `mapstructure:"vendor-options" yaml:"vendor-options" json:"vendor-options,omitempty"`
-	PrintWarnings                    bool     `mapstructure:"print-warnings" yaml:"print-warnings" json:"print_warnings"`
+	mysqlcommonconfig.ConnectionOpts `mapstructure:",squash" json:",squash,omitempty"` //nolint:staticcheck
+	VendorOptions                    []string                                          `mapstructure:"vendor-options" yaml:"vendor-options" json:"vendor-options,omitempty"`
+	PrintWarnings                    bool                                              `mapstructure:"print-warnings" yaml:"print-warnings" json:"print_warnings"`
 	// MaxFetchWarnings - the maximum number of warnings to fetch and print. If 0, all warnings are printed.
 	MaxFetchWarnings        int  `mapstructure:"max-fetch-warnings" yaml:"max-fetch-warnings" json:"max_fetch_warnings"`
 	DisableForeignKeyChecks bool `mapstructure:"disable-fk-checks" yaml:"disable-fk-checks" json:"disable_fk_checks"`
@@ -91,15 +92,26 @@ type CommonRestoreOptions struct {
 	// CreateDatabase controls whether greenmask issues CREATE DATABASE statements before restoring schema.
 	CreateDatabase bool `mapstructure:"create-database" yaml:"create-database" json:"create_database"`
 	// IfNotExists adds IF NOT EXISTS to CREATE DATABASE and (in future) other object creation statements.
-	IfNotExists bool                 `mapstructure:"if-not-exists" yaml:"if-not-exists" json:"if_not_exists"`
-	Section     []string             `mapstructure:"section"       yaml:"section"       json:"section,omitempty"`
-	SSL         commonconfig.SSLOpts `mapstructure:",squash" json:",squash,omitempty"` //nolint:staticcheck
+	IfNotExists bool `mapstructure:"if-not-exists" yaml:"if-not-exists" json:"if_not_exists"`
+	// RemapDatabase maps original database names to new names (original → renamed).
+	RemapDatabase map[string]string `mapstructure:"remap-database" yaml:"remap-database" json:"remap-database,omitempty"`
+	// DatabaseReplaceMode controls mapping strictness: "strict" (default) requires all databases in the dump
+	// to have a mapping entry; "relaxed" renames only the listed databases and keeps the rest as-is.
+	DatabaseReplaceMode commonmodels.DatabaseReplacementMode `mapstructure:"database-replace-mode" yaml:"database-replace-mode" json:"database-replace-mode,omitempty"`
+	Section             []string                             `mapstructure:"section"               yaml:"section"               json:"section,omitempty"`
+	SSL                 commonconfig.SSLOpts                 `mapstructure:",squash"               json:",squash,omitempty"` //nolint:staticcheck
 }
 
 func (o *CommonRestoreOptions) Validate() error {
 	for _, s := range o.Section {
 		if _, ok := knownRestoreSections[s]; !ok {
 			return fmt.Errorf("unknown section %q: must be one of pre-data, data, post-data", s)
+		}
+	}
+
+	if o.DatabaseReplaceMode != "" {
+		if err := o.DatabaseReplaceMode.Validate(); err != nil {
+			return fmt.Errorf("invalid database replace mode: %w", err)
 		}
 	}
 	return nil
@@ -127,6 +139,10 @@ func NewRestore() Restore {
 			},
 			MaxFetchWarnings:       DefaultMaxFetchWarnings,
 			MaxInsertStatementSize: DefaultMaxInsertStatementSize,
+		},
+		Options: CommonRestoreOptions{
+			RemapDatabase:       make(map[string]string),
+			DatabaseReplaceMode: commonmodels.DatabaseReplaceModeStrict,
 		},
 	}
 }

--- a/pkg/config/restore_test.go
+++ b/pkg/config/restore_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+)
+
+func TestCommonRestoreOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        CommonRestoreOptions
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "empty mode is valid (field omitted from config)",
+			opts: CommonRestoreOptions{DatabaseReplaceMode: ""},
+		},
+		{
+			name: "strict mode is valid",
+			opts: CommonRestoreOptions{DatabaseReplaceMode: commonmodels.DatabaseReplaceModeStrict},
+		},
+		{
+			name: "relaxed mode is valid",
+			opts: CommonRestoreOptions{DatabaseReplaceMode: commonmodels.DatabaseReplaceModeRelaxed},
+		},
+		{
+			name:        "unknown mode is invalid",
+			opts:        CommonRestoreOptions{DatabaseReplaceMode: "foobar"},
+			wantErr:     true,
+			errContains: "invalid database replace mode",
+		},
+		{
+			name: "known sections are valid",
+			opts: CommonRestoreOptions{Section: []string{"pre-data", "data", "post-data"}},
+		},
+		{
+			name:        "unknown section is invalid",
+			opts:        CommonRestoreOptions{Section: []string{"bad-section"}},
+			wantErr:     true,
+			errContains: "unknown section",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCommonRestoreOptions_RemapDatabase_ViaViper(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantRemap map[string]string
+		wantMode  commonmodels.DatabaseReplacementMode
+	}{
+		{
+			name: "remap-database with relaxed mode",
+			yaml: `
+restore:
+  options:
+    remap-database:
+      mydb: targetdb
+    database-replace-mode: relaxed
+`,
+			wantRemap: map[string]string{"mydb": "targetdb"},
+			wantMode:  commonmodels.DatabaseReplaceModeRelaxed,
+		},
+		{
+			name: "remap-database without explicit mode",
+			yaml: `
+restore:
+  options:
+    remap-database:
+      srcdb: dstdb
+`,
+			wantRemap: map[string]string{"srcdb": "dstdb"},
+			wantMode:  "",
+		},
+		{
+			name: "remap-database with multiple entries",
+			yaml: `
+restore:
+  options:
+    remap-database:
+      db1: tgt1
+      db2: tgt2
+    database-replace-mode: strict
+`,
+			wantRemap: map[string]string{"db1": "tgt1", "db2": "tgt2"},
+			wantMode:  commonmodels.DatabaseReplaceModeStrict,
+		},
+		{
+			name:      "no remap config",
+			yaml:      "restore:\n  options:\n    data-only: true\n",
+			wantRemap: nil,
+			wantMode:  "",
+		},
+	}
+
+	decoderCfg := func(cfg *mapstructure.DecoderConfig) { cfg.ErrorUnused = true }
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("yaml")
+			require.NoError(t, v.ReadConfig(strings.NewReader(tc.yaml)))
+
+			var cfg Config
+			require.NoError(t, v.Unmarshal(&cfg, decoderCfg))
+			assert.Equal(t, tc.wantRemap, cfg.Restore.Options.RemapDatabase)
+			assert.Equal(t, tc.wantMode, cfg.Restore.Options.DatabaseReplaceMode)
+			assert.NoError(t, cfg.Restore.Options.Validate())
+		})
+	}
+}

--- a/pkg/mysql/cmdrun/restore/restore.go
+++ b/pkg/mysql/cmdrun/restore/restore.go
@@ -81,6 +81,29 @@ func (d *Restore) connect() (*sql.DB, error) {
 	return conn, nil
 }
 
+func (d *Restore) remapDB(meta models.Metadata) (map[string]string, error) {
+	remap := d.cfg.Restore.Options.RemapDatabase
+	if len(remap) == 0 {
+		return nil, nil
+	}
+	mode := d.cfg.Restore.Options.DatabaseReplaceMode
+	if mode == "" {
+		mode = models.DatabaseReplaceModeStrict
+	}
+	switch mode {
+	case models.DatabaseReplaceModeStrict:
+		for _, db := range meta.Databases {
+			if _, ok := remap[db]; !ok {
+				return nil, fmt.Errorf("database-replace-mode=strict: database %q has no entry in remap-database", db)
+			}
+		}
+	case models.DatabaseReplaceModeRelaxed:
+	default:
+		return nil, fmt.Errorf("unknown database-replace-mode %q", mode)
+	}
+	return remap, nil
+}
+
 func (d *Restore) Run(ctx context.Context) error {
 	if err := d.cfg.Restore.MysqlConfig.Validate(); err != nil {
 		return fmt.Errorf("validate mysql options: %w", err)
@@ -111,6 +134,11 @@ func (d *Restore) Run(ctx context.Context) error {
 
 	taskResolver := taskmapper.NewTaskResolver()
 
+	remap, err := d.remapDB(meta)
+	if err != nil {
+		return fmt.Errorf("remapDB: %w", err)
+	}
+
 	var tp interfaces.RestoreTaskProducer
 	opts := taskproducer.RestoreOptions{
 		PrintWarnings:           d.cfg.Restore.MysqlConfig.PrintWarnings,
@@ -120,6 +148,7 @@ func (d *Restore) Run(ctx context.Context) error {
 		InsertIgnore:            d.cfg.Restore.MysqlConfig.InsertIgnore,
 		InsertReplace:           d.cfg.Restore.MysqlConfig.InsertReplace,
 		MaxInsertStatementSize:  d.cfg.Restore.MysqlConfig.MaxInsertStatementSize,
+		DatabaseRemap:           remap,
 	}
 
 	if d.cfg.Restore.Options.RestoreInOrder {
@@ -142,6 +171,9 @@ func (d *Restore) Run(ctx context.Context) error {
 	}
 	if d.cfg.Restore.Options.IfNotExists {
 		schemaOpts = append(schemaOpts, schema.WithIfNotExists())
+	}
+	if len(remap) > 0 {
+		schemaOpts = append(schemaOpts, schema.WithDatabaseRemap(remap))
 	}
 	sr := schema.NewRestorer(d.st, &d.cfg.Restore.MysqlConfig, d.cfg.Restore.Options.SSL, d.cmd, meta.SchemaDump, schemaOpts...)
 

--- a/pkg/mysql/cmdrun/restore/restore_remap_test.go
+++ b/pkg/mysql/cmdrun/restore/restore_remap_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/greenmaskio/greenmask/pkg/config"
+)
+
+func newRestoreWithRemap(remap map[string]string, mode models.DatabaseReplacementMode) *Restore {
+	cfg := &config.Config{}
+	cfg.Restore.Options.RemapDatabase = remap
+	cfg.Restore.Options.DatabaseReplaceMode = mode
+	return &Restore{cfg: cfg}
+}
+
+func TestRestore_remapDB(t *testing.T) {
+	tests := []struct {
+		name        string
+		remap       map[string]string
+		mode        models.DatabaseReplacementMode
+		databases   []string
+		wantRemap   map[string]string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "nil remap returns nil regardless of mode",
+			remap:     nil,
+			mode:      models.DatabaseReplaceModeStrict,
+			databases: []string{"mydb"},
+			wantRemap: nil,
+		},
+		{
+			name:      "empty remap returns nil regardless of mode",
+			remap:     map[string]string{},
+			mode:      models.DatabaseReplaceModeStrict,
+			databases: []string{"mydb"},
+			wantRemap: nil,
+		},
+		{
+			name:      "strict mode — all databases mapped — returns remap",
+			remap:     map[string]string{"src": "dst", "src2": "dst2"},
+			mode:      models.DatabaseReplaceModeStrict,
+			databases: []string{"src", "src2"},
+			wantRemap: map[string]string{"src": "dst", "src2": "dst2"},
+		},
+		{
+			name:        "strict mode — unmapped database — error",
+			remap:       map[string]string{"src": "dst"},
+			mode:        models.DatabaseReplaceModeStrict,
+			databases:   []string{"src", "unmapped"},
+			wantErr:     true,
+			errContains: "unmapped",
+		},
+		{
+			name:        "empty mode defaults to strict — unmapped database — error",
+			remap:       map[string]string{"src": "dst"},
+			mode:        "",
+			databases:   []string{"src", "other"},
+			wantErr:     true,
+			errContains: "other",
+		},
+		{
+			name:      "relaxed mode — unmapped database — no error",
+			remap:     map[string]string{"src": "dst"},
+			mode:      models.DatabaseReplaceModeRelaxed,
+			databases: []string{"src", "other"},
+			wantRemap: map[string]string{"src": "dst"},
+		},
+		{
+			name:      "relaxed mode — no databases in dump — no error",
+			remap:     map[string]string{"src": "dst"},
+			mode:      models.DatabaseReplaceModeRelaxed,
+			databases: nil,
+			wantRemap: map[string]string{"src": "dst"},
+		},
+		{
+			name:        "unknown mode — error",
+			remap:       map[string]string{"src": "dst"},
+			mode:        "bogus",
+			databases:   []string{"src"},
+			wantErr:     true,
+			errContains: "bogus",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRestoreWithRemap(tc.remap, tc.mode)
+			meta := models.Metadata{Databases: tc.databases}
+			got, err := r.remapDB(meta)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantRemap, got)
+			}
+		})
+	}
+}

--- a/pkg/mysql/restore/restorers/database_remap_test.go
+++ b/pkg/mysql/restore/restorers/database_remap_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restorers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/greenmaskio/greenmask/pkg/common/models"
+	commonutils "github.com/greenmaskio/greenmask/pkg/common/utils"
+	mysqlmodels "github.com/greenmaskio/greenmask/pkg/mysql/models"
+)
+
+func minimalMeta(schema, name string) models.RestorationItem {
+	table := models.Table{Schema: schema, Name: name}
+	return models.RestorationItem{
+		ObjectDefinition: commonutils.Must(json.Marshal(table)),
+	}
+}
+
+func insertMeta(schema, name string, columns ...string) models.RestorationItem {
+	cols := make([]models.Column, len(columns))
+	for i, c := range columns {
+		cols[i] = models.Column{Name: c}
+	}
+	table := models.Table{Schema: schema, Name: name, Columns: cols}
+	return models.RestorationItem{
+		ObjectDefinition: commonutils.Must(json.Marshal(table)),
+	}
+}
+
+func stubConnConfig() *mysqlmodels.ConnConfig {
+	return &mysqlmodels.ConnConfig{
+		Host: "127.0.0.1", Port: 3306,
+		User: "root", Password: "root", Database: "test",
+	}
+}
+
+func TestWithDatabaseRemap_CSV(t *testing.T) {
+	tests := []struct {
+		name       string
+		schema     string
+		remap      map[string]string
+		wantSchema string
+	}{
+		{
+			name:       "mapped schema is renamed",
+			schema:     "olddb",
+			remap:      map[string]string{"olddb": "newdb"},
+			wantSchema: "newdb",
+		},
+		{
+			name:       "unmapped schema is unchanged",
+			schema:     "mydb",
+			remap:      map[string]string{"otherdb": "newdb"},
+			wantSchema: "mydb",
+		},
+		{
+			name:       "nil remap leaves schema unchanged",
+			schema:     "mydb",
+			remap:      nil,
+			wantSchema: "mydb",
+		},
+		{
+			name:       "multiple entries — correct key selected",
+			schema:     "db2",
+			remap:      map[string]string{"db1": "tgt1", "db2": "tgt2"},
+			wantSchema: "tgt2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr, err := NewTableDataRestorerCsv(
+				minimalMeta(tc.schema, "tbl"),
+				stubConnConfig(), nil, nil,
+				WithDatabaseRemap(tc.remap),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSchema, rr.Meta()[models.MetaKeyTableSchema])
+		})
+	}
+}
+
+func TestWithDatabaseRemap_Insert(t *testing.T) {
+	tests := []struct {
+		name       string
+		schema     string
+		remap      map[string]string
+		wantSchema string
+	}{
+		{
+			name:       "mapped schema is renamed",
+			schema:     "srcdb",
+			remap:      map[string]string{"srcdb": "tgtdb"},
+			wantSchema: "tgtdb",
+		},
+		{
+			name:       "unmapped schema is unchanged",
+			schema:     "mydb",
+			remap:      map[string]string{"other": "tgt"},
+			wantSchema: "mydb",
+		},
+		{
+			name:       "nil remap leaves schema unchanged",
+			schema:     "mydb",
+			remap:      nil,
+			wantSchema: "mydb",
+		},
+		{
+			name:       "multiple entries — correct key selected",
+			schema:     "db1",
+			remap:      map[string]string{"db1": "tgt1", "db2": "tgt2"},
+			wantSchema: "tgt1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr, err := NewTableDataRestorerInsert(
+				insertMeta(tc.schema, "users", "id"),
+				stubConnConfig(), nil, nil,
+				WithDatabaseRemap(tc.remap),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSchema, rr.Meta()[models.MetaKeyTableSchema])
+		})
+	}
+}

--- a/pkg/mysql/restore/restorers/table_data_restorer_csv.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_csv.go
@@ -77,6 +77,7 @@ type TableRestorerConfig struct {
 	InsertIgnore            bool
 	InsertReplace           bool
 	MaxInsertStatementSize  int
+	DatabaseRemap           map[string]string
 }
 
 type Option func(v *TableRestorerConfig) error
@@ -144,6 +145,13 @@ func WithMaxInsertStatementSize(size int) Option {
 	}
 }
 
+func WithDatabaseRemap(remap map[string]string) Option {
+	return func(v *TableRestorerConfig) error {
+		v.DatabaseRemap = remap
+		return nil
+	}
+}
+
 func NewTableDataRestorerCsv(
 	meta models.RestorationItem,
 	connConfig *mysqlmodels.ConnConfig,
@@ -163,6 +171,9 @@ func NewTableDataRestorerCsv(
 		if err := opt(cfg); err != nil {
 			return nil, fmt.Errorf("options failed: %w", err)
 		}
+	}
+	if mapped, ok := cfg.DatabaseRemap[table.Schema]; ok {
+		table.Schema = mapped
 	}
 
 	res := &TableDataRestorerCsv{

--- a/pkg/mysql/restore/restorers/table_data_restorer_insert.go
+++ b/pkg/mysql/restore/restorers/table_data_restorer_insert.go
@@ -80,6 +80,9 @@ func NewTableDataRestorerInsert(
 			return nil, fmt.Errorf("options failed: %w", err)
 		}
 	}
+	if mapped, ok := cfg.DatabaseRemap[table.Schema]; ok {
+		table.Schema = mapped
+	}
 
 	res := &TableDataRestorerInsert{
 		table:                  &table,

--- a/pkg/mysql/restore/schema/remap_test.go
+++ b/pkg/mysql/restore/schema/remap_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRestorer_remapDB(t *testing.T) {
+	tests := []struct {
+		name  string
+		remap map[string]string
+		input string
+		want  string
+	}{
+		{
+			name:  "mapped name is replaced",
+			remap: map[string]string{"src": "dst"},
+			input: "src",
+			want:  "dst",
+		},
+		{
+			name:  "unmapped name is returned unchanged",
+			remap: map[string]string{"src": "dst"},
+			input: "other",
+			want:  "other",
+		},
+		{
+			name:  "nil map returns input unchanged",
+			remap: nil,
+			input: "mydb",
+			want:  "mydb",
+		},
+		{
+			name:  "empty map returns input unchanged",
+			remap: map[string]string{},
+			input: "mydb",
+			want:  "mydb",
+		},
+		{
+			name:  "multiple entries — correct key selected",
+			remap: map[string]string{"a": "x", "b": "y"},
+			input: "b",
+			want:  "y",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Restorer{databaseRemap: tc.remap}
+			assert.Equal(t, tc.want, r.remapDB(tc.input))
+		})
+	}
+}
+
+func TestWithDatabaseRemap(t *testing.T) {
+	tests := []struct {
+		name      string
+		initial   map[string]string
+		apply     map[string]string
+		wantRemap map[string]string
+	}{
+		{
+			name:      "sets remap on empty restorer",
+			initial:   nil,
+			apply:     map[string]string{"old": "new"},
+			wantRemap: map[string]string{"old": "new"},
+		},
+		{
+			name:      "overwrites previous remap",
+			initial:   map[string]string{"a": "b"},
+			apply:     map[string]string{"x": "y"},
+			wantRemap: map[string]string{"x": "y"},
+		},
+		{
+			name:      "nil remap clears previous mapping",
+			initial:   map[string]string{"a": "b"},
+			apply:     nil,
+			wantRemap: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Restorer{databaseRemap: tc.initial}
+			WithDatabaseRemap(tc.apply)(r)
+			assert.Equal(t, tc.wantRemap, r.databaseRemap)
+		})
+	}
+}

--- a/pkg/mysql/restore/schema/restore.go
+++ b/pkg/mysql/restore/schema/restore.go
@@ -58,6 +58,20 @@ func WithIfNotExists() Option {
 	}
 }
 
+// WithDatabaseRemap sets the database name mapping applied before schema creation and restoration.
+func WithDatabaseRemap(remap map[string]string) Option {
+	return func(r *Restorer) {
+		r.databaseRemap = remap
+	}
+}
+
+func (r *Restorer) remapDB(name string) string {
+	if mapped, ok := r.databaseRemap[name]; ok {
+		return mapped
+	}
+	return name
+}
+
 // Restorer restores a MySQL schema from files stored in the dump directory.
 type Restorer struct {
 	st             interfaces.Storager
@@ -70,6 +84,7 @@ type Restorer struct {
 	databases      []string
 	createDatabase bool
 	ifNotExists    bool
+	databaseRemap  map[string]string
 }
 
 func NewRestorer(
@@ -121,18 +136,19 @@ func (r *Restorer) restoreSchemaData(ctx context.Context, dbName string, f io.Re
 
 func (r *Restorer) createDatabases(ctx context.Context) error {
 	for _, db := range r.databases {
+		target := r.remapDB(db)
 		var stmt string
 		if r.ifNotExists {
-			stmt = fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)
+			stmt = fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", target)
 		} else {
-			stmt = fmt.Sprintf("CREATE DATABASE `%s`", db)
+			stmt = fmt.Sprintf("CREATE DATABASE `%s`", target)
 		}
 		log.Ctx(ctx).Debug().
-			Str("DatabaseName", db).
+			Str("DatabaseName", target).
 			Str("Query", stmt).
 			Msg("creating database")
 		if _, err := r.conn.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("create database %q: %w", db, err)
+			return fmt.Errorf("create database %q: %w", target, err)
 		}
 	}
 	return nil
@@ -183,8 +199,10 @@ func (r *Restorer) RestorePostDataSchema(ctx context.Context) error {
 }
 
 func (r *Restorer) restoreDatabaseSchema(ctx context.Context, schemaStat commonmodels.DumpedDatabaseSchemaStat) error {
+	target := r.remapDB(schemaStat.DatabaseName)
 	log.Ctx(ctx).Info().
 		Str("Database", schemaStat.DatabaseName).
+		Str("TargetDatabase", target).
 		Str("Section", string(schemaStat.Section)).
 		Str("FileName", schemaStat.FileName).
 		Msg("restoring database schema")
@@ -209,7 +227,7 @@ func (r *Restorer) restoreDatabaseSchema(ctx context.Context, schemaStat commonm
 		}
 	}()
 
-	if err := r.restoreSchemaData(ctx, schemaStat.DatabaseName, reader); err != nil {
+	if err := r.restoreSchemaData(ctx, target, reader); err != nil {
 		return fmt.Errorf("restore schema data: %w", err)
 	}
 	return nil

--- a/pkg/mysql/restore/taskproducer/producer.go
+++ b/pkg/mysql/restore/taskproducer/producer.go
@@ -37,6 +37,7 @@ type RestoreOptions struct {
 	InsertIgnore            bool
 	InsertReplace           bool
 	MaxInsertStatementSize  int
+	DatabaseRemap           map[string]string
 }
 
 type dummyTaskMapper struct{}
@@ -127,6 +128,9 @@ func (p *Producer) Task() (interfaces.Restorer, error) {
 		}
 		if p.opts.InsertReplace {
 			opts = append(opts, restorers.WithInsertReplace())
+		}
+		if len(p.opts.DatabaseRemap) > 0 {
+			opts = append(opts, restorers.WithDatabaseRemap(p.opts.DatabaseRemap))
 		}
 
 		stat := p.meta.DataDump.DumpStat.TaskStats[taskID]

--- a/pkg/mysql/restore/taskproducer/producer_with_order.go
+++ b/pkg/mysql/restore/taskproducer/producer_with_order.go
@@ -144,6 +144,9 @@ func (p *ProducerWithOrder) Task() (interfaces.Restorer, error) {
 		if p.opts.InsertReplace {
 			opts = append(opts, restorers.WithInsertReplace())
 		}
+		if len(p.opts.DatabaseRemap) > 0 {
+			opts = append(opts, restorers.WithDatabaseRemap(p.opts.DatabaseRemap))
+		}
 		stat := p.meta.DataDump.DumpStat.TaskStats[currentTaskID]
 		switch stat.ObjectStat.Format {
 		case models.DumpFormatInsert:

--- a/tests/integration/e2e/features/remap/remap_e2e_test.go
+++ b/tests/integration/e2e/features/remap/remap_e2e_test.go
@@ -1,0 +1,297 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package remap_e2e contains end-to-end integration tests for the database
+// remap-database feature.
+//
+// The tests exercise the full dump → restore pipeline against a real MySQL 8.4
+// container.  Each case dumps one or more source databases and then restores
+// them using a remap-database mapping, verifying that rows land in the correct
+// target database and that strict / relaxed / empty-mode semantics are
+// enforced.
+package remap_e2e
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/suite"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/greenmaskio/greenmask/pkg/common/transformers/registry"
+	"github.com/greenmaskio/greenmask/pkg/common/utils"
+	"github.com/greenmaskio/greenmask/pkg/common/validationcollector"
+	"github.com/greenmaskio/greenmask/pkg/config"
+	mysqlcmddump "github.com/greenmaskio/greenmask/pkg/mysql/cmdrun/dump"
+	mysqlcmdrestore "github.com/greenmaskio/greenmask/pkg/mysql/cmdrun/restore"
+	"github.com/greenmaskio/greenmask/pkg/storages/directory"
+	"github.com/greenmaskio/greenmask/pkg/testutils"
+)
+
+// ---------------------------------------------------------------------------
+// Source / target database names used across all test cases.
+// ---------------------------------------------------------------------------
+
+const (
+	mysqlImage = "mysql:8.4"
+
+	// Source databases created on the MySQL container.
+	srcDB     = "src_db"
+	anotherDB = "another_db"
+
+	// Common target names used in remapping scenarios.
+	dstDB = "dst_db"
+	altDB = "alt_db"
+)
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+type RemapSuite struct {
+	testutils.MySQLContainerSuite
+}
+
+func (s *RemapSuite) SetupSuite() {
+	if _, err := exec.LookPath("mysqldump"); err != nil {
+		s.T().Skip("mysqldump not found in PATH — skipping remap e2e tests")
+	}
+	if _, err := exec.LookPath("mysql"); err != nil {
+		s.T().Skip("mysql not found in PATH — skipping remap e2e tests")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		s.T().Skip("Docker is not available — skipping remap e2e tests")
+	}
+
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).Level(zerolog.DebugLevel)
+
+	s.MySQLContainerSuite.
+		SetImage(mysqlImage).
+		SetMigrationUp([]string{
+			`CREATE DATABASE IF NOT EXISTS ` + srcDB,
+			`CREATE TABLE IF NOT EXISTS ` + srcDB + `.users (
+				id   INT NOT NULL AUTO_INCREMENT,
+				name VARCHAR(255) NOT NULL,
+				PRIMARY KEY (id)
+			) ENGINE=InnoDB`,
+			`INSERT INTO ` + srcDB + `.users (name) VALUES ('alice'), ('bob'), ('carol')`,
+
+			`CREATE DATABASE IF NOT EXISTS ` + anotherDB,
+			`CREATE TABLE IF NOT EXISTS ` + anotherDB + `.items (
+				id    INT NOT NULL AUTO_INCREMENT,
+				label VARCHAR(255) NOT NULL,
+				PRIMARY KEY (id)
+			) ENGINE=InnoDB`,
+			`INSERT INTO ` + anotherDB + `.items (label) VALUES ('item1'), ('item2')`,
+		}).
+		SetupSuite()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (s *RemapSuite) setupCtx(ctx context.Context, cfg *config.Config) context.Context {
+	s.Require().NoError(utils.SetDefaultContextLogger(cfg.Log.Level, cfg.Log.Format))
+	ctx = log.Ctx(ctx).With().Str(commonmodels.MetaKeyEngine, "mysql").Logger().WithContext(ctx)
+	vc := validationcollector.NewCollectorWithMeta(commonmodels.MetaKeyEngine, "mysql")
+	return validationcollector.WithCollector(ctx, vc)
+}
+
+func (s *RemapSuite) baseConfig(ctx context.Context) *config.Config {
+	cfg := config.NewConfig()
+	cfg.Engine = commonmodels.DBMSEngineMySQL
+	cfg.Log.Level = "debug"
+	cfg.Log.Format = "text"
+
+	opts := s.GetRootConnectionOpts(ctx)
+	cfg.Dump.MysqlConfig.Host = opts.Host
+	cfg.Dump.MysqlConfig.Port = opts.Port
+	cfg.Dump.MysqlConfig.User = opts.User
+	cfg.Dump.MysqlConfig.Password = opts.Password
+	cfg.Dump.MysqlConfig.ConnectDatabase = srcDB
+	cfg.Dump.MysqlConfig.VendorOptions = []string{"--add-drop-table"}
+	cfg.Dump.Options.Compress = false
+	cfg.Dump.Options.Pgzip = false
+
+	cfg.Restore.MysqlConfig.Host = opts.Host
+	cfg.Restore.MysqlConfig.Port = opts.Port
+	cfg.Restore.MysqlConfig.User = opts.User
+	cfg.Restore.MysqlConfig.Password = opts.Password
+	cfg.Restore.MysqlConfig.ConnectDatabase = srcDB
+	cfg.Restore.Options.CreateDatabase = true
+	cfg.Restore.Options.IfNotExists = true
+
+	return cfg
+}
+
+func (s *RemapSuite) runDump(ctx context.Context, cfg *config.Config, dumpDir string, schemas []string) commonmodels.DumpID {
+	cfg.Dump.Options.IncludeSchema = schemas
+	dirSt, err := directory.New(directory.NewDirectoryConfig(dumpDir))
+	s.Require().NoError(err, "create dump storage")
+
+	d, err := mysqlcmddump.NewDump(
+		cfg,
+		registry.DefaultTransformerRegistry,
+		dirSt,
+		utils.NewDefaultCmdProducer(),
+		mysqlcmddump.GetMySQLDumpOpts(cfg)...,
+	)
+	s.Require().NoError(err, "new dump")
+	s.Require().NoError(d.Run(ctx), "run dump")
+	return d.GetDumpID()
+}
+
+func (s *RemapSuite) runRestore(ctx context.Context, cfg *config.Config, dumpDir string, dumpID commonmodels.DumpID) error {
+	dirSt, err := directory.New(directory.NewDirectoryConfig(dumpDir))
+	s.Require().NoError(err, "create restore storage")
+	return mysqlcmdrestore.RunRestore(ctx, cfg, dirSt, string(dumpID))
+}
+
+// countRows queries the given table in the given database using a root
+// connection and returns the row count.
+func (s *RemapSuite) countRows(ctx context.Context, db *sql.DB, database, table string) int {
+	var n int
+	row := db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s`", database, table))
+	s.Require().NoError(row.Scan(&n))
+	return n
+}
+
+// dropDatabases drops the listed databases if they exist.  It is called before
+// each sub-test so target databases from a previous run do not pollute results.
+func (s *RemapSuite) dropDatabases(ctx context.Context, db *sql.DB, names ...string) {
+	for _, name := range names {
+		_, err := db.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", name))
+		s.Require().NoErrorf(err, "drop database %s", name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// rowCheck describes an expected row count in a specific database and table.
+type rowCheck struct {
+	database string
+	table    string
+	wantRows int
+}
+
+func (s *RemapSuite) TestDatabaseRemap() {
+	tests := []struct {
+		name        string
+		dumpSchemas []string
+		remap       map[string]string
+		mode        commonmodels.DatabaseReplacementMode
+		dropBefore  []string
+		wantErr     bool
+		checks      []rowCheck
+	}{
+		{
+			name:        "strict_all_mapped",
+			dumpSchemas: []string{srcDB, anotherDB},
+			remap:       map[string]string{srcDB: dstDB, anotherDB: altDB},
+			mode:        commonmodels.DatabaseReplaceModeStrict,
+			dropBefore:  []string{dstDB, altDB},
+			checks: []rowCheck{
+				{database: dstDB, table: "users", wantRows: 3},
+				{database: altDB, table: "items", wantRows: 2},
+			},
+		},
+		{
+			// anotherDB has no mapping — strict mode must reject before any SQL.
+			name:        "strict_missing_entry_fails",
+			dumpSchemas: []string{srcDB, anotherDB},
+			remap:       map[string]string{srcDB: dstDB},
+			mode:        commonmodels.DatabaseReplaceModeStrict,
+			dropBefore:  []string{dstDB},
+			wantErr:     true,
+		},
+		{
+			// anotherDB has no mapping — relaxed mode keeps it under its original name.
+			name:        "relaxed_partial_map",
+			dumpSchemas: []string{srcDB, anotherDB},
+			remap:       map[string]string{srcDB: dstDB},
+			mode:        commonmodels.DatabaseReplaceModeRelaxed,
+			dropBefore:  []string{dstDB},
+			checks: []rowCheck{
+				{database: dstDB, table: "users", wantRows: 3},
+				{database: anotherDB, table: "items", wantRows: 2},
+			},
+		},
+		{
+			// Empty mode defaults to strict; single dump database is fully covered.
+			name:        "empty_mode_defaults_to_strict_single_db",
+			dumpSchemas: []string{srcDB},
+			remap:       map[string]string{srcDB: dstDB},
+			mode:        "",
+			dropBefore:  []string{dstDB},
+			checks: []rowCheck{
+				{database: dstDB, table: "users", wantRows: 3},
+			},
+		},
+		{
+			// Empty mode defaults to strict; unmapped second database must fail.
+			name:        "empty_mode_defaults_to_strict_missing_entry_fails",
+			dumpSchemas: []string{srcDB, anotherDB},
+			remap:       map[string]string{srcDB: dstDB},
+			mode:        "",
+			dropBefore:  []string{dstDB},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			ctx := context.Background()
+			cfg := s.baseConfig(ctx)
+			ctx = s.setupCtx(ctx, cfg)
+
+			db, err := s.GetRootConnection(ctx)
+			s.Require().NoError(err)
+			defer db.Close()
+
+			s.dropDatabases(ctx, db, tc.dropBefore...)
+
+			dumpDir := s.T().TempDir()
+			dumpID := s.runDump(ctx, cfg, dumpDir, tc.dumpSchemas)
+
+			cfg.Restore.Options.RemapDatabase = tc.remap
+			cfg.Restore.Options.DatabaseReplaceMode = tc.mode
+
+			err = s.runRestore(ctx, cfg, dumpDir, dumpID)
+			if tc.wantErr {
+				s.Require().Error(err)
+				return
+			}
+			s.Require().NoError(err)
+
+			for _, chk := range tc.checks {
+				got := s.countRows(ctx, db, chk.database, chk.table)
+				s.Equalf(chk.wantRows, got, "row count mismatch in %s.%s", chk.database, chk.table)
+			}
+		})
+	}
+}
+
+func TestRemapSuite(t *testing.T) {
+	suite.Run(t, new(RemapSuite))
+}


### PR DESCRIPTION
Adds `remap-database` and `database-replace-mode` restore options that redirect databases from a dump into differently-named databases on the target instance.  Both the schema restore (CREATE DATABASE + mysqldump pipe) and all data restorers (CSV LOAD DATA and batched INSERT) apply the mapping, so the full dump → restore pipeline honours it end-to-end.

Two enforcement modes are supported:
- **strict** (default) — every database present in the dump must have a mapping entry; restore fails fast if any database is unmapped.
- **relaxed** — only listed databases are renamed; unmapped databases are restored under their original names.

`DatabaseReplacementMode` is a new typed string in `pkg/common/models` with its own `Validate()` method so the type can be reused across engines.  Config validation skips the mode check when the field is omitted (empty string is treated as strict at runtime).

Example restore config:

```yaml
restore:
  options:
    create-database: true
    if-not-exists: true
    remap-database:
      production_db: staging_db
      analytics_db:  analytics_staging
    database-replace-mode: strict   # or: relaxed
```

Code increment for #222 