### PR TITLE
feat: [MySQL] add script execution to restore and integration tests

### DIFF
--- a/pkg/common/models/script.go
+++ b/pkg/common/models/script.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ScriptEventType string
+
+const (
+	ScriptEventTypeBefore ScriptEventType = "before"
+	ScriptEventTypeAfter  ScriptEventType = "after"
+)
+
+func (s ScriptEventType) Validate() error {
+	switch s {
+	case ScriptEventTypeBefore, ScriptEventTypeAfter:
+		return nil
+	default:
+		return fmt.Errorf("value '%s': %w", s, ErrValueValidationFailed)
+	}
+}
+
+type Script struct {
+	Name      string          `mapstructure:"name"`
+	Section   DumpSection     `mapstructure:"section"`
+	When      ScriptEventType `mapstructure:"when"`
+	Query     string          `mapstructure:"query"`
+	QueryFile string          `mapstructure:"query_file"`
+	Command   []string        `mapstructure:"command"`
+}
+
+func (s *Script) Validate() error {
+	if err := s.When.Validate(); err != nil {
+		return fmt.Errorf("validate 'when': %w", err)
+	}
+
+	values := []string{s.Query, s.QueryFile, strings.Join(s.Command, " ")}
+	var count int
+	for _, value := range values {
+		if value != "" {
+			count += 1
+		}
+	}
+	if count == 0 {
+		return fmt.Errorf("script '%s' has no values", s.Name)
+	}
+	if count > 1 {
+		return fmt.Errorf("script '%s' has more than one value", s.Name)
+	}
+	return nil
+}

--- a/pkg/common/restore/processor/processor.go
+++ b/pkg/common/restore/processor/processor.go
@@ -16,8 +16,11 @@ package processor
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
+	"github.com/greenmaskio/greenmask/pkg/common/restore/script"
+	mysqlmodels "github.com/greenmaskio/greenmask/pkg/mysql/models"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
@@ -75,9 +78,11 @@ func (c *Config) SetDefault(ctx context.Context) {
 }
 
 type DefaultRestoreProcessor struct {
-	tp  interfaces.RestoreTaskProducer
-	sr  schemaRestorer
-	cfg Config
+	tp              interfaces.RestoreTaskProducer
+	sr              schemaRestorer
+	cfg             Config
+	scriptScheduler *script.Scheduler
+	connConfig      *mysqlmodels.ConnConfig
 }
 
 func NewDefaultRestoreProcessor(
@@ -85,12 +90,16 @@ func NewDefaultRestoreProcessor(
 	tp interfaces.RestoreTaskProducer,
 	sr schemaRestorer,
 	cfg Config,
+	scripts []commonmodels.Script,
+	connConfig *mysqlmodels.ConnConfig,
 ) *DefaultRestoreProcessor {
 	cfg.SetDefault(ctx)
 	return &DefaultRestoreProcessor{
-		tp:  tp,
-		sr:  sr,
-		cfg: cfg,
+		tp:              tp,
+		sr:              sr,
+		cfg:             cfg,
+		scriptScheduler: script.NewScheduler(scripts),
+		connConfig:      connConfig,
 	}
 }
 
@@ -232,21 +241,116 @@ func (p *DefaultRestoreProcessor) dataRestore(ctx context.Context) error {
 	return nil
 }
 
+// buildTxExec opens a MySQL connection from connConfig and returns a TxExec
+// that executes SQL statements against it, plus a cleanup that closes the connection.
+// Returns (nil, no-op, nil) when connConfig is not set (no SQL scripts possible).
+func (p *DefaultRestoreProcessor) buildTxExec(ctx context.Context) (script.TxExec, func(), error) {
+	if p.connConfig == nil {
+		return nil, func() {}, nil
+	}
+	uri, err := p.connConfig.URI()
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("build script TxExec: get connection URI: %w", err)
+	}
+	db, err := sql.Open("mysql", uri)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("build script TxExec: open connection: %w", err)
+	}
+	exec := script.TxExec(func(ctx context.Context, query string) error {
+		_, err := db.ExecContext(ctx, query)
+		return err
+	})
+	return exec, func() {
+		if err := db.Close(); err != nil {
+			log.Ctx(ctx).Warn().Err(err).Msg("close script db connection")
+		}
+	}, nil
+}
+
+func (p *DefaultRestoreProcessor) restorePreDataSchema(ctx context.Context) error {
+	exec, closeDB, err := p.buildTxExec(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeDB()
+
+	if err := p.scriptScheduler.Exec(
+		ctx, exec, commonmodels.DumpSectionPreData, commonmodels.ScriptEventTypeBefore,
+	); err != nil {
+		return fmt.Errorf("execute scripts section='%s' when='%s': %w", commonmodels.DumpSectionPreData, commonmodels.ScriptEventTypeBefore, err)
+	}
+	if err := p.sr.RestorePreDataSchema(ctx); err != nil {
+		return fmt.Errorf("pre-data schema restore: %w", err)
+	}
+	if err := p.scriptScheduler.Exec(
+		ctx, exec, commonmodels.DumpSectionPreData, commonmodels.ScriptEventTypeAfter,
+	); err != nil {
+		return fmt.Errorf("execute scripts section='%s' when='%s': %w", commonmodels.DumpSectionPreData, commonmodels.ScriptEventTypeAfter, err)
+	}
+	return nil
+}
+
+func (p *DefaultRestoreProcessor) restoreData(ctx context.Context) error {
+	exec, closeDB, err := p.buildTxExec(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeDB()
+
+	if err := p.scriptScheduler.Exec(
+		ctx, exec, commonmodels.DumpSectionData, commonmodels.ScriptEventTypeBefore,
+	); err != nil {
+		return fmt.Errorf("execute scripts section='%s' when='%s': %w", commonmodels.DumpSectionData, commonmodels.ScriptEventTypeBefore, err)
+	}
+	if err := p.dataRestore(ctx); err != nil {
+		return fmt.Errorf("data restore: %w", err)
+	}
+	if err := p.scriptScheduler.Exec(
+		ctx, exec, commonmodels.DumpSectionData, commonmodels.ScriptEventTypeAfter,
+	); err != nil {
+		return fmt.Errorf("execute scripts section='%s' when='%s': %w", commonmodels.DumpSectionData, commonmodels.ScriptEventTypeAfter, err)
+	}
+	return nil
+}
+
+func (p *DefaultRestoreProcessor) restorePostDataSchema(ctx context.Context) error {
+	exec, closeDB, err := p.buildTxExec(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeDB()
+
+	if err := p.scriptScheduler.Exec(
+		ctx, exec, commonmodels.DumpSectionPostData, commonmodels.ScriptEventTypeBefore,
+	); err != nil {
+		return fmt.Errorf("execute scripts section='%s' when='%s': %w", commonmodels.DumpSectionPostData, commonmodels.ScriptEventTypeBefore, err)
+	}
+	if err := p.sr.RestorePostDataSchema(ctx); err != nil {
+		return fmt.Errorf("post-data schema restore: %w", err)
+	}
+	if err := p.scriptScheduler.Exec(
+		ctx, exec, commonmodels.DumpSectionPostData, commonmodels.ScriptEventTypeAfter,
+	); err != nil {
+		return fmt.Errorf("execute scripts section='%s' when='%s': %w", commonmodels.DumpSectionPostData, commonmodels.ScriptEventTypeAfter, err)
+	}
+	return nil
+}
+
 func (p *DefaultRestoreProcessor) Run(ctx context.Context) error {
 	if p.sectionEnabled(commonmodels.DumpSectionPreData) {
-		if err := p.sr.RestorePreDataSchema(ctx); err != nil {
+		if err := p.restorePreDataSchema(ctx); err != nil {
 			return fmt.Errorf("pre-data schema restore: %w", err)
 		}
 	}
 
 	if p.sectionEnabled(commonmodels.DumpSectionData) {
-		if err := p.dataRestore(ctx); err != nil {
+		if err := p.restoreData(ctx); err != nil {
 			return fmt.Errorf("data restore: %w", err)
 		}
 	}
 
 	if p.sectionEnabled(commonmodels.DumpSectionPostData) {
-		if err := p.sr.RestorePostDataSchema(ctx); err != nil {
+		if err := p.restorePostDataSchema(ctx); err != nil {
 			return fmt.Errorf("post-data schema restore: %w", err)
 		}
 	}

--- a/pkg/common/restore/processor/processor_test.go
+++ b/pkg/common/restore/processor/processor_test.go
@@ -137,7 +137,7 @@ func TestProcessor_Run(t *testing.T) {
 			RestoreInOrder: true,
 		}
 
-		dumpRuntime := NewDefaultRestoreProcessor(ctx, tp, sr, cfg)
+		dumpRuntime := NewDefaultRestoreProcessor(ctx, tp, sr, cfg, nil, nil) //nolint:staticcheck
 		err := dumpRuntime.Run(ctx)
 		require.NoError(t, err)
 

--- a/pkg/common/restore/script/script.go
+++ b/pkg/common/restore/script/script.go
@@ -1,0 +1,129 @@
+package script
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/greenmaskio/greenmask/pkg/common/utils"
+	"github.com/rs/zerolog/log"
+)
+
+type Scheduler struct {
+	scripts []commonmodels.Script
+}
+
+func NewScheduler(scripts []commonmodels.Script) *Scheduler {
+	return &Scheduler{
+		scripts: scripts,
+	}
+}
+
+func (s *Scheduler) Exec(
+	ctx context.Context,
+	exec TxExec,
+	currentSection commonmodels.DumpSection,
+	currentWhen commonmodels.ScriptEventType,
+) error {
+	for i := range s.scripts {
+		script := s.scripts[i]
+		if script.Section != currentSection || script.When != currentWhen {
+			continue
+		}
+		if err := NewExecutor(script).Exec(ctx, exec); err != nil {
+			return fmt.Errorf("execute script #%d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+type TxExec func(ctx context.Context, query string) error
+
+var errNothingToExecute = errors.New("nothing to execute")
+
+type Executor struct {
+	commonmodels.Script
+}
+
+func NewExecutor(script commonmodels.Script) *Executor {
+	return &Executor{
+		Script: script,
+	}
+}
+
+func (s *Executor) Validate() error {
+	if err := s.When.Validate(); err != nil {
+		return fmt.Errorf("validate 'when': %w", err)
+	}
+
+	values := []string{s.Query, s.QueryFile, strings.Join(s.Command, " ")}
+	var count int
+	for _, value := range values {
+		if value != "" {
+			count += 1
+		}
+	}
+	if count == 0 {
+		return fmt.Errorf("script '%s' has no values", s.Name)
+	}
+	if count > 1 {
+		return fmt.Errorf("script '%s' has more than one value", s.Name)
+	}
+	return nil
+}
+
+func (s *Executor) Exec(ctx context.Context, exec TxExec) error {
+	switch {
+	case s.Query != "":
+		return s.executeQuery(ctx, exec)
+	case s.QueryFile != "":
+		return s.executeQueryFile(ctx, exec)
+	case len(s.Command) > 0:
+		return s.executeCommand(ctx)
+	default:
+		return errNothingToExecute
+	}
+}
+
+func (s *Executor) executeQuery(ctx context.Context, exec TxExec) error {
+	if err := exec(ctx, s.Query); err != nil {
+		return fmt.Errorf("execute script name='%s': %w", s.Name, err)
+	}
+	return nil
+}
+
+func (s *Executor) executeQueryFile(ctx context.Context, exec TxExec) error {
+	f, err := os.Open(s.QueryFile)
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Ctx(ctx).Debug().Err(err).Msg("error closing query file")
+		}
+	}()
+	if err != nil {
+		return fmt.Errorf("cannot open script file: %w", err)
+	}
+	query, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("cannot read query file: %w", err)
+	}
+	if err := exec(ctx, string(query)); err != nil {
+		return fmt.Errorf("execute script name='%s': %w", s.Name, err)
+	}
+	return err
+}
+
+func (s *Executor) executeCommand(ctx context.Context) error {
+	log.Ctx(ctx).Debug().
+		Str("exec", s.Command[0]).
+		Str("args", strings.Join(s.Command[1:], " ")).
+		Msg("executing script")
+	cmd := utils.NewCmdRunner(s.Command[0], s.Command[1:], os.Environ())
+	if err := cmd.ExecuteCmdAndForwardStdout(ctx); err != nil {
+		return fmt.Errorf("execute script name='%s': %w", s.Name, err)
+	}
+	return nil
+}

--- a/pkg/common/restore/script/script_integration_test.go
+++ b/pkg/common/restore/script/script_integration_test.go
@@ -1,0 +1,242 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/greenmaskio/greenmask/pkg/testutils"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	integrationMigrationUp   = `CREATE TABLE script_test (id INT PRIMARY KEY, value VARCHAR(255))`
+	integrationMigrationDown = `DROP TABLE IF EXISTS script_test`
+)
+
+// dbTxExec adapts a *sql.DB into a TxExec function.
+func dbTxExec(db *sql.DB) TxExec {
+	return func(ctx context.Context, query string) error {
+		_, err := db.ExecContext(ctx, query)
+		return err
+	}
+}
+
+type scriptIntegrationSuite struct {
+	testutils.MySQLContainerSuite
+	db *sql.DB
+}
+
+func (s *scriptIntegrationSuite) SetupSuite() {
+	s.SetMigrationUp([]string{integrationMigrationUp}).
+		SetMigrationDown([]string{integrationMigrationDown})
+	s.MySQLContainerSuite.SetupSuite()
+
+	var err error
+	s.db, err = s.GetConnection(context.Background())
+	s.Require().NoError(err, "get db connection")
+	s.Require().NoError(s.db.Ping(), "ping db")
+}
+
+func (s *scriptIntegrationSuite) TearDownSuite() {
+	if s.db != nil {
+		s.db.Close()
+	}
+	s.MySQLContainerSuite.TearDownSuite()
+}
+
+// --- executeQuery ---
+
+func (s *scriptIntegrationSuite) TestExecuteQuery_Success() {
+	ctx := context.Background()
+	e := NewExecutor(commonmodels.Script{
+		Name:  "insert-row",
+		Query: "INSERT INTO script_test (id, value) VALUES (1, 'hello')",
+	})
+	err := e.executeQuery(ctx, dbTxExec(s.db))
+	s.Require().NoError(err)
+
+	var val string
+	s.Require().NoError(s.db.QueryRowContext(ctx, "SELECT value FROM script_test WHERE id = 1").Scan(&val))
+	s.Equal("hello", val)
+
+	_, _ = s.db.ExecContext(ctx, "DELETE FROM script_test WHERE id = 1")
+}
+
+func (s *scriptIntegrationSuite) TestExecuteQuery_InvalidSQL_Error() {
+	ctx := context.Background()
+	e := NewExecutor(commonmodels.Script{Name: "bad", Query: "THIS IS NOT SQL"})
+	err := e.executeQuery(ctx, dbTxExec(s.db))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "execute script name='bad'")
+}
+
+// --- executeQueryFile ---
+
+func (s *scriptIntegrationSuite) TestExecuteQueryFile_Success() {
+	ctx := context.Background()
+	dir := s.T().TempDir()
+	path := filepath.Join(dir, "insert.sql")
+	require.NoError(s.T(), os.WriteFile(path, []byte("INSERT INTO script_test (id, value) VALUES (2, 'from-file')"), 0600))
+
+	e := NewExecutor(commonmodels.Script{Name: "file-script", QueryFile: path})
+	err := e.executeQueryFile(ctx, dbTxExec(s.db))
+	s.Require().NoError(err)
+
+	var val string
+	s.Require().NoError(s.db.QueryRowContext(ctx, "SELECT value FROM script_test WHERE id = 2").Scan(&val))
+	s.Equal("from-file", val)
+
+	_, _ = s.db.ExecContext(ctx, "DELETE FROM script_test WHERE id = 2")
+}
+
+func (s *scriptIntegrationSuite) TestExecuteQueryFile_FileNotFound() {
+	ctx := context.Background()
+	e := NewExecutor(commonmodels.Script{Name: "s", QueryFile: "/nonexistent/missing.sql"})
+	err := e.executeQueryFile(ctx, dbTxExec(s.db))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "cannot open script file")
+}
+
+func (s *scriptIntegrationSuite) TestExecuteQueryFile_InvalidSQL_Error() {
+	ctx := context.Background()
+	dir := s.T().TempDir()
+	path := filepath.Join(dir, "bad.sql")
+	require.NoError(s.T(), os.WriteFile(path, []byte("NOT VALID SQL"), 0600))
+
+	e := NewExecutor(commonmodels.Script{Name: "bad-file", QueryFile: path})
+	err := e.executeQueryFile(ctx, dbTxExec(s.db))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "execute script name='bad-file'")
+}
+
+// --- Scheduler.Exec with a real DB ---
+
+func (s *scriptIntegrationSuite) TestScheduler_Exec_OnlyMatchingScriptsRun() {
+	ctx := context.Background()
+
+	scripts := []commonmodels.Script{
+		{
+			Name:    "skip-wrong-section",
+			Section: commonmodels.DumpSectionPostData,
+			When:    commonmodels.ScriptEventTypeBefore,
+			Query:   "INSERT INTO script_test (id, value) VALUES (10, 'should-not-run')",
+		},
+		{
+			Name:    "run-match",
+			Section: commonmodels.DumpSectionPreData,
+			When:    commonmodels.ScriptEventTypeBefore,
+			Query:   "INSERT INTO script_test (id, value) VALUES (11, 'should-run')",
+		},
+	}
+
+	sched := NewScheduler(scripts)
+	err := sched.Exec(ctx, dbTxExec(s.db), commonmodels.DumpSectionPreData, commonmodels.ScriptEventTypeBefore)
+	s.Require().NoError(err)
+
+	var count int
+	s.Require().NoError(s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM script_test WHERE id = 10").Scan(&count))
+	s.Equal(0, count, "non-matching script must not have run")
+
+	s.Require().NoError(s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM script_test WHERE id = 11").Scan(&count))
+	s.Equal(1, count, "matching script must have run")
+
+	_, _ = s.db.ExecContext(ctx, "DELETE FROM script_test WHERE id IN (10, 11)")
+}
+
+func (s *scriptIntegrationSuite) TestScheduler_Exec_ErrorPropagated() {
+	ctx := context.Background()
+
+	scripts := []commonmodels.Script{
+		{
+			Name:    "fail",
+			Section: commonmodels.DumpSectionData,
+			When:    commonmodels.ScriptEventTypeAfter,
+			Query:   "INVALID SQL STATEMENT",
+		},
+	}
+
+	sched := NewScheduler(scripts)
+	err := sched.Exec(ctx, dbTxExec(s.db), commonmodels.DumpSectionData, commonmodels.ScriptEventTypeAfter)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "execute script #0")
+}
+
+func (s *scriptIntegrationSuite) TestScheduler_Exec_MultipleMatchingScripts() {
+	ctx := context.Background()
+
+	scripts := []commonmodels.Script{
+		{
+			Name:    "first",
+			Section: commonmodels.DumpSectionPostData,
+			When:    commonmodels.ScriptEventTypeAfter,
+			Query:   "INSERT INTO script_test (id, value) VALUES (20, 'first')",
+		},
+		{
+			Name:    "second",
+			Section: commonmodels.DumpSectionPostData,
+			When:    commonmodels.ScriptEventTypeAfter,
+			Query:   "INSERT INTO script_test (id, value) VALUES (21, 'second')",
+		},
+	}
+
+	sched := NewScheduler(scripts)
+	err := sched.Exec(ctx, dbTxExec(s.db), commonmodels.DumpSectionPostData, commonmodels.ScriptEventTypeAfter)
+	s.Require().NoError(err)
+
+	var count int
+	s.Require().NoError(s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM script_test WHERE id IN (20, 21)").Scan(&count))
+	s.Equal(2, count)
+
+	_, _ = s.db.ExecContext(ctx, "DELETE FROM script_test WHERE id IN (20, 21)")
+}
+
+// --- Executor.Exec dispatch integration ---
+
+func (s *scriptIntegrationSuite) TestExecutorExec_QueryDispatch() {
+	ctx := context.Background()
+	called := false
+	exec := TxExec(func(_ context.Context, q string) error {
+		called = true
+		_, err := s.db.ExecContext(ctx, q)
+		return err
+	})
+	e := NewExecutor(commonmodels.Script{
+		Name:  "dispatch-query",
+		Query: "INSERT INTO script_test (id, value) VALUES (30, 'dispatch')",
+	})
+	s.Require().NoError(e.Exec(ctx, exec))
+	s.True(called)
+	_, _ = s.db.ExecContext(ctx, "DELETE FROM script_test WHERE id = 30")
+}
+
+func (s *scriptIntegrationSuite) TestExecutorExec_ErrNothingToExecute() {
+	ctx := context.Background()
+	e := NewExecutor(commonmodels.Script{Name: "empty"})
+	err := e.Exec(ctx, dbTxExec(s.db))
+	s.Require().Error(err)
+	s.True(errors.Is(err, errNothingToExecute))
+}
+
+func TestScriptIntegration(t *testing.T) {
+	suite.Run(t, new(scriptIntegrationSuite))
+}

--- a/pkg/common/restore/script/script_test.go
+++ b/pkg/common/restore/script/script_test.go
@@ -1,0 +1,386 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Scheduler.Exec ---
+
+func TestScheduler_Exec(t *testing.T) {
+	ctx := context.Background()
+	noopExec := TxExec(func(_ context.Context, _ string) error { return nil })
+
+	tests := []struct {
+		name           string
+		scripts        []commonmodels.Script
+		section        commonmodels.DumpSection
+		when           commonmodels.ScriptEventType
+		exec           TxExec
+		wantErr        bool
+		wantErrContain string
+		wantCalled     int
+	}{
+		{
+			name:       "no scripts — no error",
+			scripts:    nil,
+			section:    commonmodels.DumpSectionPreData,
+			when:       commonmodels.ScriptEventTypeBefore,
+			exec:       noopExec,
+			wantCalled: 0,
+		},
+		{
+			name: "script with non-matching section is skipped",
+			scripts: []commonmodels.Script{
+				{Name: "s", Section: commonmodels.DumpSectionPostData, When: commonmodels.ScriptEventTypeBefore, Query: "SELECT 1"},
+			},
+			section:    commonmodels.DumpSectionPreData,
+			when:       commonmodels.ScriptEventTypeBefore,
+			exec:       noopExec,
+			wantCalled: 0,
+		},
+		{
+			name: "script with non-matching when is skipped",
+			scripts: []commonmodels.Script{
+				{Name: "s", Section: commonmodels.DumpSectionPreData, When: commonmodels.ScriptEventTypeAfter, Query: "SELECT 1"},
+			},
+			section:    commonmodels.DumpSectionPreData,
+			when:       commonmodels.ScriptEventTypeBefore,
+			exec:       noopExec,
+			wantCalled: 0,
+		},
+		{
+			name: "matching script is executed",
+			scripts: []commonmodels.Script{
+				{Name: "s", Section: commonmodels.DumpSectionPreData, When: commonmodels.ScriptEventTypeBefore, Query: "SELECT 1"},
+			},
+			section:    commonmodels.DumpSectionPreData,
+			when:       commonmodels.ScriptEventTypeBefore,
+			exec:       noopExec,
+			wantCalled: 1,
+		},
+		{
+			name: "multiple matching scripts all executed",
+			scripts: []commonmodels.Script{
+				{Name: "a", Section: commonmodels.DumpSectionData, When: commonmodels.ScriptEventTypeAfter, Query: "SELECT 1"},
+				{Name: "b", Section: commonmodels.DumpSectionData, When: commonmodels.ScriptEventTypeAfter, Query: "SELECT 2"},
+			},
+			section:    commonmodels.DumpSectionData,
+			when:       commonmodels.ScriptEventTypeAfter,
+			exec:       noopExec,
+			wantCalled: 2,
+		},
+		{
+			name: "executor error is propagated with script index",
+			scripts: []commonmodels.Script{
+				{Name: "skip", Section: commonmodels.DumpSectionPreData, When: commonmodels.ScriptEventTypeBefore, Query: "SELECT 1"},
+				{Name: "fail", Section: commonmodels.DumpSectionData, When: commonmodels.ScriptEventTypeBefore, Query: "SELECT 1"},
+			},
+			section: commonmodels.DumpSectionData,
+			when:    commonmodels.ScriptEventTypeBefore,
+			exec: func(_ context.Context, _ string) error {
+				return errors.New("boom")
+			},
+			wantErr:        true,
+			wantErrContain: "execute script #1",
+		},
+		{
+			name: "mixed: only matching scripts executed, non-matching skipped",
+			scripts: []commonmodels.Script{
+				{Name: "skip", Section: commonmodels.DumpSectionPostData, When: commonmodels.ScriptEventTypeBefore, Query: "SELECT 1"},
+				{Name: "run", Section: commonmodels.DumpSectionPreData, When: commonmodels.ScriptEventTypeBefore, Query: "SELECT 2"},
+			},
+			section:    commonmodels.DumpSectionPreData,
+			when:       commonmodels.ScriptEventTypeBefore,
+			exec:       noopExec,
+			wantCalled: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := 0
+			var execFn TxExec
+			if tt.wantErr {
+				execFn = tt.exec
+			} else {
+				execFn = func(ctx context.Context, query string) error {
+					called++
+					return tt.exec(ctx, query)
+				}
+			}
+
+			s := NewScheduler(tt.scripts)
+			err := s.Exec(ctx, execFn, tt.section, tt.when)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantCalled, called)
+			}
+		})
+	}
+}
+
+// --- Executor.Validate ---
+
+func TestExecutor_Validate(t *testing.T) {
+	tests := []struct {
+		name           string
+		script         commonmodels.Script
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name: "valid with query",
+			script: commonmodels.Script{
+				Name:  "s",
+				When:  commonmodels.ScriptEventTypeBefore,
+				Query: "SELECT 1",
+			},
+		},
+		{
+			name: "valid with query_file",
+			script: commonmodels.Script{
+				Name:      "s",
+				When:      commonmodels.ScriptEventTypeBefore,
+				QueryFile: "/some/file.sql",
+			},
+		},
+		{
+			name: "valid with command",
+			script: commonmodels.Script{
+				Name:    "s",
+				When:    commonmodels.ScriptEventTypeBefore,
+				Command: []string{"echo", "hello"},
+			},
+		},
+		{
+			name: "invalid when value",
+			script: commonmodels.Script{
+				Name:  "s",
+				When:  "always",
+				Query: "SELECT 1",
+			},
+			wantErr:        true,
+			wantErrContain: "validate 'when'",
+		},
+		{
+			name: "no values set",
+			script: commonmodels.Script{
+				Name: "s",
+				When: commonmodels.ScriptEventTypeBefore,
+			},
+			wantErr:        true,
+			wantErrContain: "has no values",
+		},
+		{
+			name: "more than one value set",
+			script: commonmodels.Script{
+				Name:      "s",
+				When:      commonmodels.ScriptEventTypeBefore,
+				Query:     "SELECT 1",
+				QueryFile: "/some/file.sql",
+			},
+			wantErr:        true,
+			wantErrContain: "has more than one value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewExecutor(tt.script)
+			err := e.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- Executor.Exec dispatch ---
+
+func TestExecutor_Exec(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("query dispatched to executeQuery", func(t *testing.T) {
+		called := false
+		exec := TxExec(func(_ context.Context, q string) error {
+			called = true
+			assert.Equal(t, "SELECT 42", q)
+			return nil
+		})
+		e := NewExecutor(commonmodels.Script{Name: "s", Query: "SELECT 42"})
+		require.NoError(t, e.Exec(ctx, exec))
+		assert.True(t, called)
+	})
+
+	t.Run("query_file dispatched to executeQueryFile", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "*.sql")
+		require.NoError(t, err)
+		_, err = f.WriteString("SELECT 99")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		called := false
+		exec := TxExec(func(_ context.Context, q string) error {
+			called = true
+			assert.Equal(t, "SELECT 99", q)
+			return nil
+		})
+		e := NewExecutor(commonmodels.Script{Name: "s", QueryFile: f.Name()})
+		require.NoError(t, e.Exec(ctx, exec))
+		assert.True(t, called)
+	})
+
+	t.Run("command dispatched to executeCommand", func(t *testing.T) {
+		e := NewExecutor(commonmodels.Script{Name: "s", Command: []string{"echo", "hi"}})
+		require.NoError(t, e.Exec(ctx, nil))
+	})
+
+	t.Run("nothing set returns errNothingToExecute", func(t *testing.T) {
+		e := NewExecutor(commonmodels.Script{Name: "s"})
+		err := e.Exec(ctx, nil)
+		require.ErrorIs(t, err, errNothingToExecute)
+	})
+}
+
+// --- executeQuery ---
+
+func TestExecutor_executeQuery(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		execErr        error
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:           "exec error wrapped with script name",
+			execErr:        errors.New("db down"),
+			wantErr:        true,
+			wantErrContain: "execute script name='my-script'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewExecutor(commonmodels.Script{Name: "my-script", Query: "SELECT 1"})
+			err := e.executeQuery(ctx, func(_ context.Context, _ string) error { return tt.execErr })
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- executeQueryFile ---
+
+func TestExecutor_executeQueryFile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("file not found", func(t *testing.T) {
+		e := NewExecutor(commonmodels.Script{Name: "s", QueryFile: "/nonexistent/path/query.sql"})
+		err := e.executeQueryFile(ctx, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot open script file")
+	})
+
+	t.Run("file content passed to exec", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "q.sql")
+		require.NoError(t, os.WriteFile(path, []byte("SELECT 7"), 0600))
+
+		var gotQuery string
+		e := NewExecutor(commonmodels.Script{Name: "s", QueryFile: path})
+		err := e.executeQueryFile(ctx, func(_ context.Context, q string) error {
+			gotQuery = q
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT 7", gotQuery)
+	})
+
+	t.Run("exec error wrapped with script name", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "q.sql")
+		require.NoError(t, os.WriteFile(path, []byte("SELECT 1"), 0600))
+
+		e := NewExecutor(commonmodels.Script{Name: "my-script", QueryFile: path})
+		err := e.executeQueryFile(ctx, func(_ context.Context, _ string) error {
+			return errors.New("exec failed")
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "execute script name='my-script'")
+	})
+}
+
+// --- executeCommand ---
+
+func TestExecutor_executeCommand(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		command        []string
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name:    "valid command succeeds",
+			command: []string{"echo", "hello"},
+		},
+		{
+			name:           "unknown command fails",
+			command:        []string{"unknown-command-that-does-not-exist-xyz"},
+			wantErr:        true,
+			wantErrContain: "execute script name='s'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewExecutor(commonmodels.Script{Name: "s", Command: tt.command})
+			err := e.executeCommand(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/config/restore.go
+++ b/pkg/config/restore.go
@@ -39,14 +39,6 @@ type DataRestorationErrorExclusions struct {
 	Global GlobalDataRestorationErrorExclusions   `mapstructure:"global" yaml:"global" json:"global,omitempty"`
 }
 
-type Script struct {
-	Name      string   `mapstructure:"name"`
-	When      string   `mapstructure:"when"`
-	Query     string   `mapstructure:"query"`
-	QueryFile string   `mapstructure:"query_file"`
-	Command   []string `mapstructure:"command"`
-}
-
 const DefaultMaxFetchWarnings = 10
 
 const DefaultMaxInsertStatementSize = 4 * 1024 * 1024
@@ -127,8 +119,20 @@ type Restore struct {
 	Options          CommonRestoreOptions           `mapstructure:"options" yaml:"options" json:"options"`
 	MysqlConfig      MysqlRestoreConfig             `mapstructure:"mysql" yaml:"mysql"`
 	PostgresqlConfig PostgresqlRestoreConfig        `mapstructure:"postgresql" yaml:"postgresql"`
-	Scripts          map[string][]Script            `mapstructure:"scripts" yaml:"scripts" json:"scripts,omitempty"`
+	Scripts          []commonmodels.Script          `mapstructure:"scripts" yaml:"scripts" json:"scripts,omitempty"`
 	ErrorExclusions  DataRestorationErrorExclusions `mapstructure:"insert_error_exclusions" yaml:"insert_error_exclusions" json:"insert_error_exclusions,omitempty"`
+}
+
+func (r *Restore) Validate() error {
+	if err := r.Options.Validate(); err != nil {
+		return fmt.Errorf("validate options: %w", err)
+	}
+	for i, script := range r.Scripts {
+		if err := script.Validate(); err != nil {
+			return fmt.Errorf("validate script #%d name '%s': %w", i, script.Name, err)
+		}
+	}
+	return nil
 }
 
 func NewRestore() Restore {

--- a/pkg/mysql/cmdrun/restore/restore.go
+++ b/pkg/mysql/cmdrun/restore/restore.go
@@ -183,7 +183,7 @@ func (d *Restore) Run(ctx context.Context) error {
 		DataOnly:       d.cfg.Restore.Options.DataOnly,
 		SchemaOnly:     d.cfg.Restore.Options.SchemaOnly,
 		Section:        d.cfg.Restore.Options.Section,
-	}).Run(ctx); err != nil {
+	}, d.cfg.Restore.Scripts, d.connConfig).Run(ctx); err != nil {
 		return fmt.Errorf("run restore processor: %w", err)
 	}
 	return nil

--- a/tests/integration/features/restore/mocks_test.go
+++ b/tests/integration/features/restore/mocks_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"context"
+	"io"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/greenmaskio/greenmask/pkg/common/utils"
+)
+
+type CmdRunnerMock struct {
+	mock.Mock
+}
+
+func (m *CmdRunnerMock) ExecuteCmdAndForwardStdout(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *CmdRunnerMock) ExecuteCmdAndWriteStdout(ctx context.Context, w io.Writer) error {
+	args := m.Called(ctx, w)
+	return args.Error(0)
+}
+
+func (m *CmdRunnerMock) ExecuteCmd(ctx context.Context, w io.Writer, mode int) error {
+	args := m.Called(ctx, w, mode)
+	return args.Error(0)
+}
+
+type CmdProducerMock struct {
+	mock.Mock
+}
+
+func (m *CmdProducerMock) Produce(executable string, args []string, env []string, stdin io.Reader) (utils.CmdRunnerInterface, error) {
+	callArgs := m.Called(executable, args, env, stdin)
+	return callArgs.Get(0).(utils.CmdRunnerInterface), callArgs.Error(1)
+}

--- a/tests/integration/features/restore/restore_test.go
+++ b/tests/integration/features/restore/restore_test.go
@@ -1,0 +1,572 @@
+// Copyright 2025 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	commonmodels "github.com/greenmaskio/greenmask/pkg/common/models"
+	"github.com/greenmaskio/greenmask/pkg/common/transformers/registry"
+	"github.com/greenmaskio/greenmask/pkg/common/validationcollector"
+	"github.com/greenmaskio/greenmask/pkg/config"
+	mysqldump "github.com/greenmaskio/greenmask/pkg/mysql/cmdrun/dump"
+	mysqlrestore "github.com/greenmaskio/greenmask/pkg/mysql/cmdrun/restore"
+	"github.com/greenmaskio/greenmask/pkg/storages/validate"
+	"github.com/greenmaskio/greenmask/pkg/testutils"
+)
+
+const (
+	mysqlImage = "mysql:8.4"
+	sourceDB   = "testdb"
+	targetDB   = "restoredb"
+	testDumpID = "test-dump-id"
+)
+
+var (
+	migrationUpTable = []string{
+		`CREATE TABLE test_table (
+			id   INT          NOT NULL,
+			name VARCHAR(255) NOT NULL,
+			PRIMARY KEY (id)
+		)`,
+		`CREATE TABLE other_table (
+			id   INT          NOT NULL,
+			name VARCHAR(255) NOT NULL,
+			PRIMARY KEY (id)
+		)`,
+	}
+	migrationUpData = []string{
+		`INSERT INTO test_table  (id, name) VALUES (1,'test1'), (2,'test2')`,
+		`INSERT INTO other_table (id, name) VALUES (1,'other1')`,
+	}
+	migrationDown = []string{
+		`DROP TABLE IF EXISTS test_table`,
+		`DROP TABLE IF EXISTS other_table`,
+	}
+)
+
+// restoreTestSuite drives the MySQL-backed restore integration tests.
+// A single MySQL container is started once for the suite. Each test
+// creates a throwaway `restoredb` database, runs restore into it, then
+// drops it so the next test starts clean.
+type restoreTestSuite struct {
+	testutils.MySQLContainerSuite
+	db *sql.DB // shared connection for test setup and verification
+}
+
+func (s *restoreTestSuite) SetupSuite() {
+	s.MySQLContainerSuite.
+		SetImage(mysqlImage).
+		SetMigrationUp(append(migrationUpTable, migrationUpData...)).
+		SetMigrationDown(migrationDown).
+		SetupSuite()
+
+	var err error
+	s.db, err = s.GetRootConnection(context.Background())
+	s.Require().NoError(err)
+	s.Require().NoError(s.db.Ping())
+}
+
+func (s *restoreTestSuite) TearDownSuite() {
+	if s.db != nil {
+		_ = s.db.Close()
+	}
+	s.MySQLContainerSuite.TearDownSuite()
+}
+
+// setupInfrastructure attaches logging and a validation collector to ctx.
+func (s *restoreTestSuite) setupInfrastructure(ctx context.Context) context.Context {
+	ctx = log.Ctx(ctx).With().Str(commonmodels.MetaKeyEngine, "mysql").Logger().WithContext(ctx)
+	vc := validationcollector.NewCollectorWithMeta(commonmodels.MetaKeyEngine, "mysql")
+	return validationcollector.WithCollector(ctx, vc)
+}
+
+// createRestoreTarget creates `restoredb` and the supplied tables (fully qualified DDL).
+// The returned cleanup func drops the database.
+func (s *restoreTestSuite) createRestoreTarget(ctx context.Context, tables []string) func() {
+	_, err := s.db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+targetDB+"`")
+	s.Require().NoError(err, "create restore target database")
+	for _, ddl := range tables {
+		_, err = s.db.ExecContext(ctx, ddl)
+		s.Require().NoError(err, "create restore target table")
+	}
+	return func() {
+		_, _ = s.db.ExecContext(ctx, "DROP DATABASE IF EXISTS `"+targetDB+"`")
+	}
+}
+
+// seedTarget inserts rows into a table (used for conflict-resolution tests).
+func (s *restoreTestSuite) seedTarget(ctx context.Context, query string) {
+	_, err := s.db.ExecContext(ctx, query)
+	s.Require().NoError(err, "seed target")
+}
+
+// runDump executes a dump (real data, mocked schema) and returns the populated storage.
+func (s *restoreTestSuite) runDump(ctx context.Context, cfg *config.Config) *validate.Storage {
+	st := validate.New("")
+
+	cmdRunner := &CmdRunnerMock{}
+	cmdRunner.On("ExecuteCmdAndWriteStdout", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			_, err := args.Get(1).(io.Writer).Write([]byte("-- mock schema content"))
+			s.Require().NoError(err)
+		})
+	cmdProducer := &CmdProducerMock{}
+	cmdProducer.On("Produce", "mysqldump", mock.Anything, mock.Anything, mock.Anything).
+		Return(cmdRunner, nil)
+
+	dumpProcess, err := mysqldump.NewDump(
+		cfg,
+		registry.DefaultTransformerRegistry,
+		st,
+		cmdProducer,
+		mysqldump.GetMySQLDumpOpts(cfg)...,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(dumpProcess.Run(ctx))
+	return st
+}
+
+// runRestore runs a restore against the container. Schema sections are handled by
+// a no-op mock mysql CLI; data sections execute real INSERTs.
+func (s *restoreTestSuite) runRestore(ctx context.Context, cfg *config.Config, st *validate.Storage) {
+	cmdRunner := &CmdRunnerMock{}
+	cmdRunner.On("ExecuteCmdAndForwardStdout", mock.Anything).Return(nil)
+	cmdProducer := &CmdProducerMock{}
+	cmdProducer.On("Produce", "mysql", mock.Anything, mock.Anything, mock.Anything).
+		Return(cmdRunner, nil)
+
+	restoreProcess := mysqlrestore.NewRestore(cfg, st, testDumpID, cmdProducer)
+	s.Require().NoError(restoreProcess.Run(ctx))
+}
+
+// baseDumpConfig returns a fully-reset dump config for the container's sourceDB.
+// Calling this always resets cfg.Dump to avoid state leaking between tests
+// (config.NewConfig returns a singleton).
+func (s *restoreTestSuite) baseDumpConfig(ctx context.Context) *config.Config {
+	cfg := config.NewConfig()
+	cfg.Engine = "mysql"
+	cfg.Log.Level = "debug"
+	cfg.Log.Format = "text"
+
+	// Reset dump to defaults so previous test state doesn't leak.
+	cfg.Dump = config.NewDump()
+	opts := s.GetRootConnectionOpts(ctx)
+	cfg.Dump.MysqlConfig.Host = opts.Host
+	cfg.Dump.MysqlConfig.Port = opts.Port
+	cfg.Dump.MysqlConfig.User = opts.User
+	cfg.Dump.MysqlConfig.Password = opts.Password
+	cfg.Dump.MysqlConfig.ConnectDatabase = sourceDB
+	cfg.Dump.Options.IncludeSchema = []string{sourceDB}
+	cfg.Dump.Options.Compress = false
+	cfg.Dump.Options.Pgzip = false
+	return cfg
+}
+
+// baseRestoreConfig returns a fully-reset restore config for the container,
+// remapping sourceDB → targetDB.
+func (s *restoreTestSuite) baseRestoreConfig(ctx context.Context) *config.Config {
+	cfg := s.baseDumpConfig(ctx)
+
+	// Fully reset restore config so InsertIgnore/InsertReplace/DataOnly etc.
+	// from a prior test don't leak through the singleton.
+	cfg.Restore = config.NewRestore()
+	opts := s.GetRootConnectionOpts(ctx)
+	cfg.Restore.MysqlConfig.Host = opts.Host
+	cfg.Restore.MysqlConfig.Port = opts.Port
+	cfg.Restore.MysqlConfig.User = opts.User
+	cfg.Restore.MysqlConfig.Password = opts.Password
+	cfg.Restore.Options.RemapDatabase = map[string]string{sourceDB: targetDB}
+	cfg.Restore.Options.DatabaseReplaceMode = commonmodels.DatabaseReplaceModeStrict
+	return cfg
+}
+
+// countRows returns the number of rows in `db.table`.
+func (s *restoreTestSuite) countRows(ctx context.Context, db, table string) int {
+	var n int
+	s.Require().NoError(s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM `"+db+"`.`"+table+"`",
+	).Scan(&n))
+	return n
+}
+
+// getNames fetches all `name` values from `db.table`, ordered by id.
+func (s *restoreTestSuite) getNames(ctx context.Context, db, table string) []string {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT name FROM `"+db+"`.`"+table+"` ORDER BY id",
+	)
+	s.Require().NoError(err)
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		s.Require().NoError(rows.Scan(&n))
+		names = append(names, n)
+	}
+	s.Require().NoError(rows.Err())
+	return names
+}
+
+// targetTableExists reports whether a table exists in targetDB.
+func (s *restoreTestSuite) targetTableExists(ctx context.Context, table string) bool {
+	var n int
+	s.Require().NoError(s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
+		targetDB, table,
+	).Scan(&n))
+	return n > 0
+}
+
+// --- Tests ---
+
+func (s *restoreTestSuite) TestRestore_DataOnly() {
+	// data-only: pre-data and post-data sections are skipped entirely;
+	// only INSERT statements from the dump are executed.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table`  (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+		"CREATE TABLE `" + targetDB + "`.`other_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	cfg := s.baseRestoreConfig(ctx)
+	cfg.Restore.Options.DataOnly = true
+
+	st := s.runDump(ctx, s.baseDumpConfig(ctx))
+	defer st.Cleanup()
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(2, s.countRows(ctx, targetDB, "test_table"))
+	s.ElementsMatch([]string{"test1", "test2"}, s.getNames(ctx, targetDB, "test_table"))
+	s.Equal(1, s.countRows(ctx, targetDB, "other_table"))
+	s.ElementsMatch([]string{"other1"}, s.getNames(ctx, targetDB, "other_table"))
+}
+
+func (s *restoreTestSuite) TestRestore_FullRestore_SchemaAndData() {
+	// Full restore: schema sections run via the no-op mock mysql CLI,
+	// data sections execute real INSERTs.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table`  (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+		"CREATE TABLE `" + targetDB + "`.`other_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	cfg := s.baseRestoreConfig(ctx)
+	// DataOnly=false, SchemaOnly=false → all three sections run
+
+	st := s.runDump(ctx, s.baseDumpConfig(ctx))
+	defer st.Cleanup()
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(2, s.countRows(ctx, targetDB, "test_table"))
+	s.ElementsMatch([]string{"test1", "test2"}, s.getNames(ctx, targetDB, "test_table"))
+	s.Equal(1, s.countRows(ctx, targetDB, "other_table"))
+}
+
+func (s *restoreTestSuite) TestRestore_SchemaOnly() {
+	// schema-only: data section is skipped; target tables stay empty after restore.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	cfg := s.baseRestoreConfig(ctx)
+	cfg.Restore.Options.SchemaOnly = true
+
+	st := s.runDump(ctx, s.baseDumpConfig(ctx))
+	defer st.Cleanup()
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(0, s.countRows(ctx, targetDB, "test_table"), "schema-only must not insert rows")
+}
+
+func (s *restoreTestSuite) TestRestore_TableInclude() {
+	// Dump only test_table; other_table must not appear in the target at all.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	dumpCfg := s.baseDumpConfig(ctx)
+	dumpCfg.Dump.Options.IncludeTable = []string{sourceDB + ".test_table"}
+
+	st := s.runDump(ctx, dumpCfg)
+	defer st.Cleanup()
+
+	// baseRestoreConfig resets cfg.Dump (same singleton), but the dump already ran.
+	cfg := s.baseRestoreConfig(ctx)
+	cfg.Restore.Options.DataOnly = true
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(2, s.countRows(ctx, targetDB, "test_table"))
+	s.False(s.targetTableExists(ctx, "other_table"), "other_table must not exist in target")
+}
+
+func (s *restoreTestSuite) TestRestore_InsertIgnore() {
+	// Pre-seed target with id=1; INSERT IGNORE must leave that row untouched
+	// and insert only the non-conflicting row (id=2).
+	// Dump only test_table to keep the target simple.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	s.seedTarget(ctx, "INSERT INTO `"+targetDB+"`.`test_table` (id, name) VALUES (1, 'existing')")
+
+	dumpCfg := s.baseDumpConfig(ctx)
+	dumpCfg.Dump.Options.IncludeTable = []string{sourceDB + ".test_table"}
+
+	st := s.runDump(ctx, dumpCfg)
+	defer st.Cleanup()
+
+	cfg := s.baseRestoreConfig(ctx)
+	cfg.Restore.Options.DataOnly = true
+	cfg.Restore.MysqlConfig.InsertIgnore = true
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(2, s.countRows(ctx, targetDB, "test_table"))
+
+	var name string
+	s.Require().NoError(s.db.QueryRowContext(ctx,
+		"SELECT name FROM `"+targetDB+"`.`test_table` WHERE id = 1",
+	).Scan(&name))
+	s.Equal("existing", name, "INSERT IGNORE must not overwrite conflicting row")
+}
+
+func (s *restoreTestSuite) TestRestore_InsertReplace() {
+	// Pre-seed target with id=1; INSERT REPLACE must overwrite that row
+	// with the value from the dump.
+	// Dump only test_table to keep the target simple.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	s.seedTarget(ctx, "INSERT INTO `"+targetDB+"`.`test_table` (id, name) VALUES (1, 'stale')")
+
+	dumpCfg := s.baseDumpConfig(ctx)
+	dumpCfg.Dump.Options.IncludeTable = []string{sourceDB + ".test_table"}
+
+	st := s.runDump(ctx, dumpCfg)
+	defer st.Cleanup()
+
+	cfg := s.baseRestoreConfig(ctx)
+	cfg.Restore.Options.DataOnly = true
+	cfg.Restore.MysqlConfig.InsertReplace = true
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(2, s.countRows(ctx, targetDB, "test_table"))
+
+	var name string
+	s.Require().NoError(s.db.QueryRowContext(ctx,
+		"SELECT name FROM `"+targetDB+"`.`test_table` WHERE id = 1",
+	).Scan(&name))
+	s.Equal("test1", name, "INSERT REPLACE must overwrite conflicting row with dump value")
+}
+
+func (s *restoreTestSuite) TestRestore_DatabaseRemap() {
+	// Verify remap-database redirects rows to the remapped DB while leaving
+	// the source DB untouched.
+	ctx := s.setupInfrastructure(context.Background())
+
+	cleanup := s.createRestoreTarget(ctx, []string{
+		"CREATE TABLE `" + targetDB + "`.`test_table`  (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+		"CREATE TABLE `" + targetDB + "`.`other_table` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+	})
+	defer cleanup()
+
+	cfg := s.baseRestoreConfig(ctx)
+	cfg.Restore.Options.DataOnly = true
+
+	st := s.runDump(ctx, s.baseDumpConfig(ctx))
+	defer st.Cleanup()
+
+	s.runRestore(ctx, cfg, st)
+
+	s.Equal(2, s.countRows(ctx, sourceDB, "test_table"), "source must be unchanged")
+	s.Equal(2, s.countRows(ctx, targetDB, "test_table"), "target must have restored rows")
+}
+
+// TestRestore_Scripts exercises every combination of section (pre-data / data /
+// post-data), event (before / after), and script type (sql / sql-file /
+// command) as a table-driven suite of sub-tests.
+//
+// SQL and sql-file scripts insert a unique marker row into a `script_log`
+// tracking table that is pre-created in the target database; command scripts
+// create a temp file via `touch`.  After restore each sub-test asserts the
+// expected side-effect is present, proving the script actually executed.
+//
+// Section / DataOnly interaction:
+//   - pre-data and post-data scripts run only when DataOnly=false (the
+//     processor must enter those sections).  The MySQL CLI is mocked so no
+//     real DDL is applied; tables are pre-created by the test helper.
+//   - data scripts are tested with DataOnly=true for simplicity.
+func (s *restoreTestSuite) TestRestore_Scripts() {
+	type scriptKind string
+	const (
+		kindSQL     scriptKind = "sql"
+		kindSQLFile scriptKind = "sql-file"
+		kindCommand scriptKind = "command"
+	)
+
+	tests := []struct {
+		name    string
+		section commonmodels.DumpSection
+		when    commonmodels.ScriptEventType
+		kind    scriptKind
+	}{
+		// pre-data section
+		{name: "pre_data_before_sql", section: commonmodels.DumpSectionPreData, when: commonmodels.ScriptEventTypeBefore, kind: kindSQL},
+		{name: "pre_data_after_sql", section: commonmodels.DumpSectionPreData, when: commonmodels.ScriptEventTypeAfter, kind: kindSQL},
+		{name: "pre_data_before_sql_file", section: commonmodels.DumpSectionPreData, when: commonmodels.ScriptEventTypeBefore, kind: kindSQLFile},
+		{name: "pre_data_after_sql_file", section: commonmodels.DumpSectionPreData, when: commonmodels.ScriptEventTypeAfter, kind: kindSQLFile},
+		{name: "pre_data_before_command", section: commonmodels.DumpSectionPreData, when: commonmodels.ScriptEventTypeBefore, kind: kindCommand},
+		{name: "pre_data_after_command", section: commonmodels.DumpSectionPreData, when: commonmodels.ScriptEventTypeAfter, kind: kindCommand},
+		// data section
+		{name: "data_before_sql", section: commonmodels.DumpSectionData, when: commonmodels.ScriptEventTypeBefore, kind: kindSQL},
+		{name: "data_after_sql", section: commonmodels.DumpSectionData, when: commonmodels.ScriptEventTypeAfter, kind: kindSQL},
+		{name: "data_before_sql_file", section: commonmodels.DumpSectionData, when: commonmodels.ScriptEventTypeBefore, kind: kindSQLFile},
+		{name: "data_after_sql_file", section: commonmodels.DumpSectionData, when: commonmodels.ScriptEventTypeAfter, kind: kindSQLFile},
+		{name: "data_before_command", section: commonmodels.DumpSectionData, when: commonmodels.ScriptEventTypeBefore, kind: kindCommand},
+		{name: "data_after_command", section: commonmodels.DumpSectionData, when: commonmodels.ScriptEventTypeAfter, kind: kindCommand},
+		// post-data section
+		{name: "post_data_before_sql", section: commonmodels.DumpSectionPostData, when: commonmodels.ScriptEventTypeBefore, kind: kindSQL},
+		{name: "post_data_after_sql", section: commonmodels.DumpSectionPostData, when: commonmodels.ScriptEventTypeAfter, kind: kindSQL},
+		{name: "post_data_before_sql_file", section: commonmodels.DumpSectionPostData, when: commonmodels.ScriptEventTypeBefore, kind: kindSQLFile},
+		{name: "post_data_after_sql_file", section: commonmodels.DumpSectionPostData, when: commonmodels.ScriptEventTypeAfter, kind: kindSQLFile},
+		{name: "post_data_before_command", section: commonmodels.DumpSectionPostData, when: commonmodels.ScriptEventTypeBefore, kind: kindCommand},
+		{name: "post_data_after_command", section: commonmodels.DumpSectionPostData, when: commonmodels.ScriptEventTypeAfter, kind: kindCommand},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			ctx := s.setupInfrastructure(context.Background())
+
+			// Pre-create target DB: script_log for SQL/file scripts plus the
+			// regular data tables so data restore and mocked schema both succeed.
+			cleanup := s.createRestoreTarget(ctx, []string{
+				"CREATE TABLE `" + targetDB + "`.`script_log` " +
+					"(id INT AUTO_INCREMENT PRIMARY KEY, marker VARCHAR(255) NOT NULL)",
+				"CREATE TABLE `" + targetDB + "`.`test_table` " +
+					"(id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+				"CREATE TABLE `" + targetDB + "`.`other_table` " +
+					"(id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))",
+			})
+			defer cleanup()
+
+			cfg := s.baseRestoreConfig(ctx)
+			// DataOnly skips pre-data/post-data sections entirely; only use it
+			// for data-section scripts where schema processing is irrelevant.
+			cfg.Restore.Options.DataOnly = tc.section == commonmodels.DumpSectionData
+
+			var scr commonmodels.Script
+			var markerFile string // populated only for kindCommand
+
+			switch tc.kind {
+			case kindSQL:
+				// Use fully-qualified table name: the script connection has no
+				// default database (ConnectDatabase is unset in the restore config).
+				scr = commonmodels.Script{
+					Name:    tc.name,
+					Section: tc.section,
+					When:    tc.when,
+					Query: fmt.Sprintf(
+						"INSERT INTO `%s`.`script_log` (marker) VALUES ('%s')",
+						targetDB, tc.name,
+					),
+				}
+
+			case kindSQLFile:
+				dir := s.T().TempDir()
+				path := filepath.Join(dir, "script.sql")
+				content := fmt.Sprintf(
+					"INSERT INTO `%s`.`script_log` (marker) VALUES ('%s')",
+					targetDB, tc.name,
+				)
+				s.Require().NoError(os.WriteFile(path, []byte(content), 0600))
+				scr = commonmodels.Script{
+					Name:      tc.name,
+					Section:   tc.section,
+					When:      tc.when,
+					QueryFile: path,
+				}
+
+			case kindCommand:
+				dir := s.T().TempDir()
+				markerFile = filepath.Join(dir, tc.name+".marker")
+				scr = commonmodels.Script{
+					Name:    tc.name,
+					Section: tc.section,
+					When:    tc.when,
+					Command: []string{"touch", markerFile},
+				}
+			}
+
+			cfg.Restore.Scripts = []commonmodels.Script{scr}
+
+			st := s.runDump(ctx, s.baseDumpConfig(ctx))
+			defer st.Cleanup()
+
+			s.runRestore(ctx, cfg, st)
+
+			switch tc.kind {
+			case kindSQL, kindSQLFile:
+				var count int
+				s.Require().NoError(s.db.QueryRowContext(ctx,
+					"SELECT COUNT(*) FROM `"+targetDB+"`.`script_log` WHERE marker = ?",
+					tc.name,
+				).Scan(&count))
+				s.Equal(1, count, "script must insert exactly one marker row into script_log")
+
+			case kindCommand:
+				_, err := os.Stat(markerFile)
+				s.NoError(err, "command script must create the marker file")
+			}
+		})
+	}
+}
+
+func TestRestoreSuite(t *testing.T) {
+	suite.Run(t, new(restoreTestSuite))
+}


### PR DESCRIPTION
Implements before/after script hooks for all three restore sections (pre-data, data, post-data).  Scripts can be an inline SQL query, a SQL file, or an arbitrary shell command, and are configured under `restore.scripts` in the YAML config.

Key changes:
- `pkg/common/models/script.go` — Script model with Query, QueryFile, Command fields and ScriptEventType (before/after)
- `pkg/common/restore/script/` — Executor and Scheduler that dispatch the correct script type and filter by section+event
- `pkg/common/restore/processor/processor.go` — processor wires script execution around each section phase; opens a dedicated DB connection from connConfig so SQL scripts target the restore instance
- `pkg/config/restore.go` — exposes Scripts []Script in Restore config
- `pkg/mysql/cmdrun/restore/restore.go` — passes scripts and connConfig into the processor

Adds integration tests
(`tests/integration/features/restore/restore_test.go`) covering all 18 combinations of section * event * script type:
- SQL inline query writes a marker row to a tracking table
- SQL file does the same via QueryFile
- Command script creates a temp marker file via `touch`

Increment for #222 

## Usage examples

All scripts are declared under `restore.scripts`.  Each entry must set
exactly one of `query`, `query_file`, or `command`.

### Inline SQL query

Run a SQL statement before data is loaded — useful for disabling
triggers or resetting sequences:

```yaml
restore:
  scripts:
    - name: disable-triggers
      section: data
      when: before
      query: "SET SESSION sql_mode = 'NO_AUTO_VALUE_ON_ZERO'"

    - name: re-enable-triggers
      section: data
      when: after
      query: "SET SESSION sql_mode = DEFAULT"
```

### SQL file

Load a SQL file for longer scripts (schema patches, seed data, etc.):

```yaml
restore:
  scripts:
    - name: patch-schema
      section: pre-data
      when: after
      query_file: /migrations/patch_20250503.sql

    - name: seed-reference-data
      section: post-data
      when: after
      query_file: /seeds/reference_data.sql
```

### Shell command

Run an arbitrary executable.  The first element is the binary; the rest
are arguments passed as-is:

```yaml
restore:
  scripts:
    - name: notify-start
      section: pre-data
      when: before
      command: ["curl", "-sf", "https://hooks.example.com/restore-started"]

    - name: warm-cache
      section: post-data
      when: after
      command: ["python3", "/scripts/warm_cache.py", "--env", "staging"]
```

### Mixed — all three types in one config

```yaml
restore:
  options:
    remap-database:
      production_db: staging_db
  scripts:
    - name: drop-analytics-views
      section: pre-data
      when: before
      query: "DROP VIEW IF EXISTS `staging_db`.`v_daily_stats`"

    - name: apply-schema-patch
      section: pre-data
      when: after
      query_file: /patches/add_audit_columns.sql

    - name: disable-fk-checks
      section: data
      when: before
      query: "SET FOREIGN_KEY_CHECKS = 0"

    - name: enable-fk-checks
      section: data
      when: after
      query: "SET FOREIGN_KEY_CHECKS = 1"

    - name: rebuild-search-index
      section: post-data
      when: after
      command: ["php", "/app/artisan", "scout:import", "App\\Models\\Product"]
```