### PR TITLE
fix: initialize exclusion constraint

### DIFF
--- a/internal/db/postgres/context/config_builder_test.go
+++ b/internal/db/postgres/context/config_builder_test.go
@@ -863,6 +863,48 @@ func Test_validateDoesInheritedConditionHaveAllColumns(t *testing.T) {
 	}
 }
 
+func Test_getTableConstraints_exclusionConstraint(t *testing.T) {
+	ctx := context.Background()
+	connStr, cleanup, err := runPostgresContainer(ctx)
+	require.NoError(t, err)
+	defer cleanup()
+
+	con, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer con.Close(ctx) // nolint: errcheck
+
+	const schema = `
+		CREATE TABLE test_exclusion (
+			id INT,
+			EXCLUDE USING btree (id WITH =)
+		);
+	`
+	require.NoError(t, initTables(ctx, con, schema))
+
+	tx, err := con.Begin(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx) // nolint: errcheck
+
+	// Resolve the OID of the test table
+	var tableOid toolkit.Oid
+	err = tx.QueryRow(ctx,
+		`SELECT c.oid FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'test_exclusion'`,
+	).Scan(&tableOid)
+	require.NoError(t, err)
+
+	constraints, err := getTableConstraints(ctx, tx, tableOid, testContainerPgVersion*10000)
+	require.NoError(t, err)
+
+	var exclusionFound bool
+	for _, c := range constraints {
+		if c.Type() == toolkit.ExclusionConstraintType {
+			exclusionFound = true
+			break
+		}
+	}
+	require.True(t, exclusionFound, "expected exclusion constraint to be present in result")
+}
+
 // runPostgresContainer starts a PostgreSQL container and returns the connection string
 func runPostgresContainer(ctx context.Context) (string, func(), error) {
 	req := testcontainers.ContainerRequest{

--- a/internal/db/postgres/context/tables_introspection.go
+++ b/internal/db/postgres/context/tables_introspection.go
@@ -147,7 +147,13 @@ func getTableConstraints(ctx context.Context, tx pgx.Tx, tableOid toolkit.Oid, v
 				Definition: constraintDefinition,
 			}
 		case 'p':
-			pk = toolkit.NewPrimaryKey(constraintSchema, constraintName, constraintDefinition, constraintOid, constraintColumns)
+			pk = toolkit.NewPrimaryKey(
+				constraintSchema,
+				constraintName,
+				constraintDefinition,
+				constraintOid,
+				constraintColumns,
+			)
 			c = pk
 		case 'u':
 			c = &toolkit.Unique{
@@ -165,6 +171,14 @@ func getTableConstraints(ctx context.Context, tx pgx.Tx, tableOid toolkit.Oid, v
 				Columns:    constraintColumns,
 				Definition: constraintDefinition,
 			}
+		case 'x':
+			c = toolkit.NewExclusion(
+				constraintSchema,
+				constraintName,
+				constraintDefinition,
+				constraintOid,
+				constraintColumns,
+			)
 		case 'n':
 			// Ignore not null constraint as it's introspected in table definition query.
 			// Before pg18 it was only for domain types, since 18 all null constraints
@@ -174,7 +188,13 @@ func getTableConstraints(ctx context.Context, tx pgx.Tx, tableOid toolkit.Oid, v
 				Msg("ignoring table constraint")
 			continue
 		default:
-			return nil, fmt.Errorf("unknown constraint type %c", constraintType)
+			log.Warn().
+				Str("ConstraintType", string(constraintType)).
+				Str("ConstraintName", constraintName).
+				Str("ConstraintSchema", constraintSchema).
+				Msg("unknown constraint type: skipping; " +
+					"please report a bug at https://github.com/GreenmaskIO/greenmask/issues/new")
+			continue
 		}
 		constraints = append(constraints, c)
 	}


### PR DESCRIPTION
As was reported in #451 an exclusion constraint in the schema forces greenmask exit with an error, as the 'x' kind of constraint was not initialized accordingly. This MR fixes this behavior.