### PR TITLE
feat(storage): add SSH/SFTP storage backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,34 +32,33 @@ lint:
 up:
 	docker-compose up playground-dbs-filler
 
-local-build:
-	DOCKER_BUILDKIT=1 \
-		docker build \
-			-f docker/greenmask/Dockerfile \
-			. \
-			-t greenmask-from-source:latest \
-			--platform linux/amd64 \
-			--target build
-
 # Select the storage backend for the playground, e.g.:
 #   make greenmask-from-source STORAGE_BACKEND=azure
-# Supported values: s3 (default, Minio) and azure (Azurite/Azure Blob). The
-# azure value layers docker-compose-azure.yml over the base file, which
-# overrides the `playground-storage` service with an Azurite emulator.
+# Supported values: s3 (default, Minio), azure (Azurite/Azure Blob) and ssh
+# (atmoz/sftp SFTP server). The azure and ssh values layer their respective
+# override file over the base file, swapping the `playground-storage` service.
 STORAGE_BACKEND ?= s3
 ifeq ($(STORAGE_BACKEND),azure)
 GREENMASK_COMPOSE := -f docker-compose.yml -f docker-compose-azure.yml
+else ifeq ($(STORAGE_BACKEND),ssh)
+GREENMASK_COMPOSE := -f docker-compose.yml -f docker-compose-ssh.yml
 else ifeq ($(STORAGE_BACKEND),s3)
 GREENMASK_COMPOSE := -f docker-compose.yml
 else
-$(error Unsupported STORAGE_BACKEND "$(STORAGE_BACKEND)"; use "s3" or "azure")
+$(error Unsupported STORAGE_BACKEND "$(STORAGE_BACKEND)"; use "s3", "azure" or "ssh")
 endif
 
 greenmask-latest:
 	docker compose $(GREENMASK_COMPOSE) run greenmask
 
-greenmask-from-source: local-build
-	docker compose $(GREENMASK_COMPOSE) run greenmask-from-source
+# Build the `greenmask-from-source` compose service image and then run it. The
+# explicit build step is required because `docker compose run` does not rebuild
+# on its own, so without it the container keeps running a stale, cached image.
+# DOCKER_BUILD_FLAGS (e.g. --no-cache) is forwarded to this build so a clean
+# rebuild actually reaches the image the container runs.
+greenmask-from-source:
+	docker compose $(GREENMASK_COMPOSE) build $(DOCKER_BUILD_FLAGS) greenmask-from-source
+	docker compose $(GREENMASK_COMPOSE) run --rm greenmask-from-source
 
 integration:
 	docker buildx build --load -t greenmask-test-dbs-filler:latest -f docker/integration/filldb/Dockerfile docker/integration/filldb

--- a/cmd/greenmask/cmd/delete/delete_dump.go
+++ b/cmd/greenmask/cmd/delete/delete_dump.go
@@ -49,7 +49,7 @@ var (
 		//Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var dumpId string
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Fatal().Err(err).Msg("")
 			}
 
@@ -72,6 +72,11 @@ func run(dumpId string) error {
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			log.Warn().Err(err).Msg("error closing storage")
+		}
+	}()
 
 	if pruneUnsafe && !pruneFailed {
 		log.Fatal().Msg("--include-unsafe works only with --prune-failed")
@@ -96,7 +101,7 @@ func run(dumpId string) error {
 			log.Fatal().Err(err).Msg("error deleting dumps elder than date")
 		}
 	} else if dumpId != "" {
-		if err := deleteDump(dumpId); err != nil {
+		if err := deleteDump(ctx, st, dumpId); err != nil {
 			log.Fatal().Err(err).Msg("error deleting dump")
 		}
 	} else {
@@ -106,15 +111,7 @@ func run(dumpId string) error {
 	return nil
 }
 
-func deleteDump(dumpId string) error {
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	st, err := builder.GetStorage(ctx, &Config.Storage, &Config.Log)
-	if err != nil {
-		log.Fatal().Err(err).Msg("")
-	}
-
+func deleteDump(ctx context.Context, st storages.Storager, dumpId string) error {
 	_, dirs, err := st.ListDir(ctx)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
@@ -125,6 +122,10 @@ func deleteDump(dumpId string) error {
 	}) {
 		return fmt.Errorf("dump with id %s was not found", dumpId)
 	}
+
+	log.Info().
+		Str("DumpId", dumpId).
+		Msg("deleting dump")
 
 	if err = st.DeleteAll(ctx, dumpId); err != nil {
 		return fmt.Errorf("storage error: %s", err)

--- a/cmd/greenmask/cmd/dump/dump.go
+++ b/cmd/greenmask/cmd/dump/dump.go
@@ -36,7 +36,7 @@ var (
 		Use:   "dump",
 		Short: "perform a logical dump, transform data, and store it in storage",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Fatal().Err(err).Msg("")
 			}
 
@@ -46,6 +46,11 @@ var (
 			if err != nil {
 				log.Fatal().Err(err).Msg("fatal")
 			}
+			defer func() {
+				if err := st.Close(); err != nil {
+					log.Warn().Err(err).Msg("error closing storage")
+				}
+			}()
 			st = st.SubStorage(strconv.FormatInt(time.Now().UnixMilli(), 10), true)
 
 			if Config.Common.TempDirectory == "" {

--- a/cmd/greenmask/cmd/list_dumps/list_dumps.go
+++ b/cmd/greenmask/cmd/list_dumps/list_dumps.go
@@ -40,7 +40,7 @@ var (
 		Use:   "list-dumps",
 		Short: "list all dumps in the storage",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Err(err).Msg("")
 			}
 
@@ -76,6 +76,11 @@ func listDumps(quiet bool) error {
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			log.Warn().Err(err).Msg("error closing storage")
+		}
+	}()
 
 	_, dirs, err := st.ListDir(ctx)
 	if err != nil {

--- a/cmd/greenmask/cmd/list_transformers/list_transformers.go
+++ b/cmd/greenmask/cmd/list_transformers/list_transformers.go
@@ -38,7 +38,7 @@ var (
 		Use:   "list-transformers",
 		Short: "list of the allowed transformers with documentation",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Err(err).Msg("")
 			}
 

--- a/cmd/greenmask/cmd/restore/restore.go
+++ b/cmd/greenmask/cmd/restore/restore.go
@@ -45,7 +45,7 @@ var (
 		Short: "restore dump with ID or the latest to the target database",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Fatal().Err(err).Msg("fatal")
 			}
 
@@ -55,6 +55,11 @@ var (
 			if err != nil {
 				log.Fatal().Err(err).Msg("fatal")
 			}
+			defer func() {
+				if err := st.Close(); err != nil {
+					log.Warn().Err(err).Msg("error closing storage")
+				}
+			}()
 
 			dumpId, err := getDumpId(ctx, st, args[0])
 			if err != nil {

--- a/cmd/greenmask/cmd/show_dump/show_dump.go
+++ b/cmd/greenmask/cmd/show_dump/show_dump.go
@@ -45,7 +45,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			var dumpId string
 
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Fatal().Err(err).Msg("error setting up logger")
 			}
 
@@ -55,6 +55,11 @@ var (
 			if err != nil {
 				log.Fatal().Err(err).Msg("error building storage")
 			}
+			defer func() {
+				if err := st.Close(); err != nil {
+					log.Warn().Err(err).Msg("error closing storage")
+				}
+			}()
 
 			if args[0] == latestDumpName {
 				var backupNames []string

--- a/cmd/greenmask/cmd/show_transformer/show_transformer.go
+++ b/cmd/greenmask/cmd/show_transformer/show_transformer.go
@@ -38,7 +38,7 @@ var (
 		Args:  cobra.ExactArgs(1),
 		Short: "show transformer details",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+			if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 				log.Err(err).Msg("")
 			}
 

--- a/cmd/greenmask/cmd/validate/validate.go
+++ b/cmd/greenmask/cmd/validate/validate.go
@@ -41,7 +41,7 @@ var (
 )
 
 func run(cmd *cobra.Command, args []string) {
-	if err := logger.SetLogLevel(Config.Log.Level, Config.Log.Format); err != nil {
+	if err := logger.SetDefaultContextLogger(Config.Log.Level, Config.Log.Format); err != nil {
 		log.Err(err).Msg("")
 	}
 
@@ -78,6 +78,11 @@ func run(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal().Err(err).Msg("cannot initialize remote storage for schema diff")
 		}
+		defer func() {
+			if err := remoteSt.Close(); err != nil {
+				log.Warn().Err(err).Msg("error closing storage")
+			}
+		}()
 	}
 
 	validateCmd, err := cmdInternals.NewValidate(Config, utils.DefaultTransformerRegistry, validate.New(""), remoteSt)

--- a/docker-compose-ssh.yml
+++ b/docker-compose-ssh.yml
@@ -1,0 +1,39 @@
+# SSH/SFTP storage override for the playground.
+#
+# Layered on top of docker-compose.yml, it overrides the `playground-storage`
+# service so the Minio (S3) backend is swapped for an atmoz/sftp SFTP server.
+# Everything else (playground-db, playground-dbs-filler, greenmask,
+# greenmask-from-source) is inherited from the base file unchanged.
+#
+# Run it (note both -f flags, base first):
+#
+#   docker compose -f docker-compose.yml -f docker-compose-ssh.yml run --rm greenmask
+#
+# Inside the shell (config-ssh.yml is mounted from ./playground):
+#
+#   greenmask --config config-ssh.yml dump
+#   greenmask --config config-ssh.yml list-dumps
+#   greenmask --config config-ssh.yml restore latest
+#
+# Tear everything down:
+#
+#   docker compose -f docker-compose.yml -f docker-compose-ssh.yml down -v
+services:
+  # Overrides the base Minio service with an atmoz/sftp SFTP server.
+  # greenmask/greenmask-from-source already depend on `playground-storage`, so
+  # reusing the name is enough to repoint them at the SFTP server.
+  playground-storage:
+    image: atmoz/sftp:alpine
+    # Override the base entrypoint (`sh`) with atmoz/sftp's own entrypoint so the
+    # `command` below is interpreted as a user spec and not by a shell.
+    entrypoint: /entrypoint
+    # Creates user "greenmask" with password "greenmask" and an auto-created,
+    # writable "dumps" subdir — so no one-shot init job is needed.
+    command: greenmask:greenmask:::dumps
+    ports:
+      - "2222:22"
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "22"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ In the `log` section of the configuration, you can specify the following setting
 ## `storage` section
 
 In the `storage` section, you can configure the storage driver for storing the dumped data. Currently,
-three storage `type` options are supported: `directory`, `s3` and `azure`.
+four storage `type` options are supported: `directory`, `s3`, `azure` and `ssh`.
 
 === "`directory` option"
 
@@ -198,6 +198,35 @@ three storage `type` options are supported: `directory`, `s3` and `azure`.
         container: "mycontainer"
         prefix: "backups"
         access_key: "<account_access_key>"
+    ```
+
+=== "`ssh` option"
+
+    The `ssh` storage option stores dump data on a remote host over SSH/SFTP. Here are the parameters
+    you can configure:
+
+    * `host` — **(required)** the SSH server hostname or IP address
+    * `user` — **(required)** the SSH user name
+    * `port` — the SSH port (default `22`)
+    * `password` — password authentication (provide at least one of `password` or `private_key_path`)
+    * `private_key_path` — path to a PEM-encoded private key for public-key authentication (provide at least one of `password` or `private_key_path`)
+    * `prefix` — the remote root path where the dump data will be stored
+
+    !!! warning "Host key verification is disabled"
+
+        Host-key checking is currently disabled (the connection trusts any host key).
+        A `known_hosts`-based verification option is a planned `TODO`.
+
+    ```yaml title="ssh storage config example"
+    storage:
+      type: ssh
+      ssh:
+        host: sftp.example.com
+        port: 22
+        user: greenmask
+        private_key_path: /home/greenmask/.ssh/id_ed25519
+        # password: "..."        # alternative to private_key_path
+        prefix: /backups/greenmask
     ```
 
 ## `dump` section

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -6,7 +6,7 @@ Greenmask Playground is a sandbox environment in Docker with sample databases in
 
 * **Original database** — the source database you'll be working with.
 * **Empty database for restoration** — an empty database where the restored data will be placed.
-* **MinIO storage** — used for storage purposes (an Azurite-based Azure Blob backend is also available — see [Using the Azure Blob storage backend](#using-the-azure-blob-storage-backend)).
+* **MinIO storage** — used for storage purposes (an Azurite-based Azure Blob backend is also available — see [Using the Azure Blob storage backend](#using-the-azure-blob-storage-backend) — as well as an SFTP backend — see [Using the SSH storage backend](#using-the-ssh-storage-backend)).
 * **Greenmask Utility** — Greenmask itself, ready for use.
 
 !!! warning
@@ -80,6 +80,40 @@ greenmask --config config-azure.yml restore latest
     ```
 
     `docker-compose-azure.yml` is an override that swaps the `playground-storage` service for an Azurite emulator, so the base file must be passed first.
+
+## Using the SSH storage backend
+
+You can also run the playground against an [atmoz/sftp](https://github.com/atmoz/sftp) SFTP server to exercise the `ssh` storage backend with a full dump/restore cycle.
+
+Pass `STORAGE_BACKEND=ssh` to the `make` targets to switch the backend:
+
+```shell
+# Run with the published image against the SFTP server
+make greenmask-latest STORAGE_BACKEND=ssh
+
+# Or build from source and run against the SFTP server
+make greenmask-from-source STORAGE_BACKEND=ssh
+```
+
+The `STORAGE_BACKEND` parameter defaults to `s3`, so omitting it (or passing `STORAGE_BACKEND=s3`) uses the default MinIO (S3) backend.
+
+Inside the container, the matching configuration is mounted as `config-ssh.yml`:
+
+```shell
+greenmask --config config-ssh.yml dump
+greenmask --config config-ssh.yml list-dumps
+greenmask --config config-ssh.yml restore latest
+```
+
+!!! Tip
+
+    If you prefer to invoke Docker Compose directly instead of the `make` targets, run:
+
+    ```shell
+    docker compose -f docker-compose.yml -f docker-compose-ssh.yml run greenmask
+    ```
+
+    `docker-compose-ssh.yml` is an override that swaps the `playground-storage` service for an atmoz/sftp SFTP server, so the base file must be passed first.
 
 ## Playground Workflow
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/sftp v1.13.10
 	github.com/rs/zerolog v1.35.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/spaolacci/murmur3 v1.1.0
@@ -72,6 +73,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260324052639-156f7da3f749 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBF
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -174,6 +176,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/sftp v1.13.10 h1:+5FbKNTe5Z9aspU88DPIKJ9z2KZoaGCu6Sr6kKR/5mU=
+github.com/pkg/sftp v1.13.10/go.mod h1:bJ1a7uDhrX/4OII+agvy28lzRvQrmIQuaHrcI1HbeGA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/domains/config.go
+++ b/internal/domains/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/greenmaskio/greenmask/internal/storages/azure"
 	"github.com/greenmaskio/greenmask/internal/storages/directory"
 	"github.com/greenmaskio/greenmask/internal/storages/s3"
+	sshstorage "github.com/greenmaskio/greenmask/internal/storages/ssh"
 	"github.com/greenmaskio/greenmask/pkg/toolkit"
 )
 
@@ -49,6 +50,7 @@ func NewConfig() *Config {
 					S3:        s3.NewConfig(),
 					Azure:     azure.NewConfig(),
 					Directory: directory.NewConfig(),
+					SSH:       sshstorage.NewConfig(),
 				},
 			}
 		},
@@ -85,10 +87,11 @@ type Common struct {
 }
 
 type StorageConfig struct {
-	Type      string            `mapstructure:"type" yaml:"type" json:"type,omitempty"`
-	S3        *s3.Config        `mapstructure:"s3"  json:"s3,omitempty" yaml:"s3"`
-	Azure     *azure.Config     `mapstructure:"azure" json:"azure,omitempty" yaml:"azure"`
-	Directory *directory.Config `mapstructure:"directory" json:"directory,omitempty" yaml:"directory"`
+	Type      string             `mapstructure:"type" yaml:"type" json:"type,omitempty"`
+	S3        *s3.Config         `mapstructure:"s3"  json:"s3,omitempty" yaml:"s3"`
+	Azure     *azure.Config      `mapstructure:"azure" json:"azure,omitempty" yaml:"azure"`
+	Directory *directory.Config  `mapstructure:"directory" json:"directory,omitempty" yaml:"directory"`
+	SSH       *sshstorage.Config `mapstructure:"ssh" json:"ssh,omitempty" yaml:"ssh"`
 }
 
 type LogConfig struct {

--- a/internal/storages/azure/azure.go
+++ b/internal/storages/azure/azure.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package azure implements the Storager interface on top of Azure Blob Storage.
+// The implementation is inspired by wal-g's pkg/storages/azure.
 package azure
 
 import (
@@ -273,6 +275,12 @@ func (s *Storage) Stat(fileName string) (*domains.ObjectStat, error) {
 		LastModified: *props.LastModified,
 		Exist:        true,
 	}, nil
+}
+
+// Close is a no-op: the Azure blob client manages its own pooled HTTP
+// connections, so there is nothing for the storage to release.
+func (s *Storage) Close() error {
+	return nil
 }
 
 // fixPrefix normalizes a path prefix for Azure: it trims any leading slash

--- a/internal/storages/azure/config.go
+++ b/internal/storages/azure/config.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-// Defaults and constants ported from wal-g pkg/storages/azure/configure.go
+// Defaults and constants for the Azure Blob Storage backend.
 const (
 	minBufferSize     = 1024
 	defaultBufferSize = 8 * 1024 * 1024
@@ -87,9 +87,8 @@ func (c *Config) Validate() error {
 }
 
 // resolveAuth picks the credential method based on which secret is set and
-// normalizes the SAS token's leading "?". This mirrors wal-g's
-// configureAuthType and is factored out so auth dispatch is unit-testable
-// without creating a real client.
+// normalizes the SAS token's leading "?". It is factored out so auth dispatch
+// is unit-testable without creating a real client.
 func resolveAuth(c *Config) (at authType, sasToken, accessKey string) {
 	if c.AccessKey != "" {
 		return authTypeAccessKey, "", c.AccessKey

--- a/internal/storages/builder/builder.go
+++ b/internal/storages/builder/builder.go
@@ -18,22 +18,27 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/greenmaskio/greenmask/internal/domains"
 	"github.com/greenmaskio/greenmask/internal/storages"
 	"github.com/greenmaskio/greenmask/internal/storages/azure"
 	"github.com/greenmaskio/greenmask/internal/storages/directory"
 	"github.com/greenmaskio/greenmask/internal/storages/s3"
+	sshstorage "github.com/greenmaskio/greenmask/internal/storages/ssh"
 )
 
 const (
 	DirectoryStorageType = "directory"
 	S3StorageType        = "s3"
 	AzureStorageType     = "azure"
+	SSHStorageType       = "ssh"
 )
 
 func GetStorage(ctx context.Context, stCfg *domains.StorageConfig, logCgf *domains.LogConfig) (
 	storages.Storager, error,
 ) {
+	log.Ctx(ctx).Debug().Str("type", stCfg.Type).Msg("creating storage")
 
 	switch stCfg.Type {
 	case DirectoryStorageType:
@@ -48,6 +53,11 @@ func GetStorage(ctx context.Context, stCfg *domains.StorageConfig, logCgf *domai
 			return nil, fmt.Errorf("azure storage config validation failed: %w", err)
 		}
 		return azure.NewStorage(ctx, stCfg.Azure, logCgf.Level)
+	case SSHStorageType:
+		if err := stCfg.SSH.Validate(); err != nil {
+			return nil, fmt.Errorf("ssh storage config validation failed: %w", err)
+		}
+		return sshstorage.NewStorage(stCfg.SSH)
 	}
 	return nil, fmt.Errorf("unknown storage type: '%s'", stCfg.Type)
 }

--- a/internal/storages/directory/directory.go
+++ b/internal/storages/directory/directory.go
@@ -211,3 +211,8 @@ func (s *Storage) Stat(fileName string) (*domains.ObjectStat, error) {
 		Exist:        true,
 	}, nil
 }
+
+// Close is a no-op: the directory backend holds no resources to release.
+func (s *Storage) Close() error {
+	return nil
+}

--- a/internal/storages/s3/s3.go
+++ b/internal/storages/s3/s3.go
@@ -374,6 +374,12 @@ func (s *Storage) Stat(fileName string) (*domains.ObjectStat, error) {
 	}, nil
 }
 
+// Close is a no-op: the S3 client manages its own pooled HTTP connections, so
+// there is nothing for the storage to release.
+func (s *Storage) Close() error {
+	return nil
+}
+
 func fixPrefix(prefix string) string {
 	if prefix != "" && prefix[len(prefix)-1] != '/' {
 		prefix = prefix + "/"

--- a/internal/storages/ssh/config.go
+++ b/internal/storages/ssh/config.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import "fmt"
+
+const defaultPort = 22
+
+type Config struct {
+	Host           string `mapstructure:"host"`             // required
+	Port           int    `mapstructure:"port"`             // default 22
+	User           string `mapstructure:"user"`             // required
+	Password       string `mapstructure:"password"`         // auth: password
+	PrivateKeyPath string `mapstructure:"private_key_path"` // auth: private key
+	Prefix         string `mapstructure:"prefix"`           // remote root path
+}
+
+func NewConfig() *Config {
+	return &Config{Port: defaultPort}
+}
+
+func (c *Config) Validate() error {
+	if c.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+	if c.User == "" {
+		return fmt.Errorf("user is required")
+	}
+	if c.Password == "" && c.PrivateKeyPath == "" {
+		return fmt.Errorf("one of password or private_key_path is required")
+	}
+	if c.Port <= 0 {
+		c.Port = defaultPort
+	}
+	return nil
+}

--- a/internal/storages/ssh/sftp_lazy.go
+++ b/internal/storages/ssh/sftp_lazy.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/pkg/sftp"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/crypto/ssh"
+)
+
+// errStorageClosed is returned by Client() once the storage has been closed.
+var errStorageClosed = errors.New("ssh storage is closed")
+
+// SFTPClient is the subset of *sftp.Client used by the storage. It is kept as
+// an interface so the dependency surface stays small and explicit.
+type SFTPClient interface {
+	ReadDir(path string) ([]os.FileInfo, error)
+	Join(elem ...string) string
+	Remove(path string) error
+	RemoveDirectory(path string) error
+	Stat(p string) (os.FileInfo, error)
+	Open(path string) (*sftp.File, error)
+	Create(path string) (*sftp.File, error)
+	MkdirAll(path string) error
+}
+
+// sftpLazy establishes the SSH/SFTP connection on the first Client() call and
+// reuses it in all subsequent calls (shared across every SubStorage clone).
+// Close() releases the connection; it must be called by the lifecycle owner
+// (e.g. a long-running server) — otherwise the connection, its receive
+// goroutine and its socket leak until the process exits.
+type sftpLazy struct {
+	address string
+	config  *ssh.ClientConfig
+
+	mu        sync.Mutex
+	sftp      SFTPClient
+	ssh       *ssh.Client
+	connErr   error
+	attempted bool
+	closed    bool
+}
+
+func newSFTPLazy(addr string, config *ssh.ClientConfig) *sftpLazy {
+	return &sftpLazy{
+		address: addr,
+		config:  config,
+	}
+}
+
+func (l *sftpLazy) Client(ctx context.Context) (SFTPClient, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return nil, errStorageClosed
+	}
+	// Connect only on the first call; reuse the connection afterwards. The
+	// outcome (success or failure) is cached for the lifetime of this storage.
+	if l.attempted {
+		return l.sftp, l.connErr
+	}
+	l.attempted = true
+
+	sftpClient, sshClient, err := connect(ctx, l.address, l.config)
+	if err != nil {
+		l.connErr = fmt.Errorf("lazy SSH connection error: %w", err)
+		return nil, l.connErr
+	}
+	l.sftp = sftpClient
+	l.ssh = sshClient
+	return l.sftp, nil
+}
+
+// Close releases the underlying connection. It is idempotent and safe to call
+// before the connection has been established. Closing the SSH client tears down
+// the TCP connection, which also unblocks and stops the sftp receive goroutine;
+// we deliberately close the SSH client rather than sftp.Client.Close(), which
+// can hang on a wedged connection because it waits on that receive loop.
+func (l *sftpLazy) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.closed = true
+	if l.ssh == nil {
+		return nil // never connected (or already torn down)
+	}
+	err := l.ssh.Close()
+	l.ssh = nil
+	l.sftp = nil
+	return err
+}
+
+func connect(ctx context.Context, addr string, config *ssh.ClientConfig) (*sftp.Client, *ssh.Client, error) {
+	sshClient, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to %s via SSH: %w", addr, err)
+	}
+
+	sftpClient, err := sftp.NewClient(sshClient)
+	if err != nil {
+		// The SSH client owns the TCP connection; close it so a failed SFTP
+		// handshake does not leak the socket. A close error here only matters
+		// for diagnostics — surface it via the context logger, but still return
+		// the original (more useful) SFTP error to the caller.
+		if cerr := sshClient.Close(); cerr != nil {
+			log.Ctx(ctx).Warn().Err(cerr).Str("address", addr).
+				Msg("error closing SSH client after failed SFTP handshake")
+		}
+		return nil, nil, fmt.Errorf("failed to connect to %s via SFTP: %w", addr, err)
+	}
+
+	return sftpClient, sshClient, nil
+}

--- a/internal/storages/ssh/ssh.go
+++ b/internal/storages/ssh/ssh.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ssh implements the Storager interface on top of SSH/SFTP.
+// The implementation is inspired by wal-g's pkg/storages/sh.
+package ssh
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/greenmaskio/greenmask/internal/storages"
+	"github.com/greenmaskio/greenmask/internal/storages/domains"
+)
+
+// defaultBufferSize is the 64 MiB read buffer used by GetObject.
+const defaultBufferSize = 64 << 20
+
+// *Storage owns a persistent SSH connection and must be closed by its owner.
+var _ io.Closer = (*Storage)(nil)
+
+type Storage struct {
+	cfg      *Config
+	sftpLazy *sftpLazy
+	cwd      string // current remote dir (root = cfg.Prefix)
+}
+
+func NewStorage(cfg *Config) (*Storage, error) {
+	authMethods, err := buildAuthMethods(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User: cfg.User,
+		Auth: authMethods,
+		// TODO: verify host keys when greenmask gains a known_hosts option
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	address := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+
+	return &Storage{
+		cfg:      cfg,
+		sftpLazy: newSFTPLazy(address, sshConfig),
+		cwd:      cfg.Prefix,
+	}, nil
+}
+
+// buildAuthMethods assembles the SSH auth methods so the private key (if
+// configured) precedes the password. It is factored out so the auth ordering
+// and key parsing are unit-testable without opening a connection.
+func buildAuthMethods(cfg *Config) ([]ssh.AuthMethod, error) {
+	var authMethods []ssh.AuthMethod
+	if cfg.PrivateKeyPath != "" {
+		pkey, err := os.ReadFile(cfg.PrivateKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("read SSH private key: %w", err)
+		}
+		signer, err := ssh.ParsePrivateKey(pkey)
+		if err != nil {
+			return nil, fmt.Errorf("parse SSH private key: %w", err)
+		}
+		authMethods = append(authMethods, ssh.PublicKeys(signer))
+	}
+	if cfg.Password != "" {
+		authMethods = append(authMethods, ssh.Password(cfg.Password))
+	}
+	return authMethods, nil
+}
+
+// Close releases the shared SSH/SFTP connection. It must be called once by the
+// lifecycle owner when the storage and all of its sub-storages are no longer
+// needed; otherwise the connection, its receive goroutine and its socket leak
+// until the process exits. SubStorage clones share the same connection, so only
+// the connection is closed (not the clone) — Close is idempotent and safe to
+// call more than once and before the connection has been established.
+func (s *Storage) Close() error {
+	return s.sftpLazy.Close()
+}
+
+func (s *Storage) GetCwd() string {
+	return s.cwd
+}
+
+func (s *Storage) Dirname() string {
+	return path.Base(s.cwd)
+}
+
+func (s *Storage) ListDir(ctx context.Context) (files []string, dirs []storages.Storager, err error) {
+	client, err := s.sftpLazy.Client(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	filesInfo, err := client.ReadDir(s.cwd)
+	if os.IsNotExist(err) {
+		// A nonexistent dir is treated as an empty one.
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read SFTP dir %q: %w", s.cwd, err)
+	}
+
+	for _, fileInfo := range filesInfo {
+		if fileInfo.IsDir() {
+			dirs = append(dirs, &Storage{
+				cfg:      s.cfg,
+				sftpLazy: s.sftpLazy,
+				cwd:      client.Join(s.cwd, fileInfo.Name()),
+			})
+			continue
+		}
+		files = append(files, fileInfo.Name())
+	}
+	return files, dirs, nil
+}
+
+func (s *Storage) GetObject(ctx context.Context, filePath string) (reader io.ReadCloser, err error) {
+	client, err := s.sftpLazy.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	objPath := path.Join(s.cwd, filePath)
+	file, err := client.Open(objPath)
+	if err != nil {
+		// Any open failure (including a missing file) maps to not found.
+		return nil, storages.ErrFileNotFound
+	}
+
+	return struct {
+		io.Reader
+		io.Closer
+	}{bufio.NewReaderSize(file, defaultBufferSize), file}, nil
+}
+
+func (s *Storage) PutObject(ctx context.Context, filePath string, body io.Reader) error {
+	client, err := s.sftpLazy.Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	absolutePath := path.Join(s.cwd, filePath)
+	dirPath := path.Dir(absolutePath)
+	if err = client.MkdirAll(dirPath); err != nil {
+		return fmt.Errorf("create directory %q via SFTP: %w", dirPath, err)
+	}
+
+	file, err := client.Create(absolutePath)
+	if err != nil {
+		return fmt.Errorf("create file %q via SFTP: %w", absolutePath, err)
+	}
+
+	done := make(chan struct{})
+	var copyErr error
+	go func() {
+		_, copyErr = io.Copy(file, body)
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		if cerr := file.Close(); cerr != nil {
+			log.Warn().Err(cerr).Str("path", absolutePath).Msg("error closing file after context cancellation")
+		}
+		return ctx.Err()
+	case <-done:
+	}
+
+	if copyErr != nil {
+		if cerr := file.Close(); cerr != nil {
+			log.Warn().Err(cerr).Str("path", absolutePath).Msg("error closing file after failed write")
+		}
+		return fmt.Errorf("write data to file %q via SFTP: %w", absolutePath, copyErr)
+	}
+
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("close file %q opened via SFTP: %w", absolutePath, err)
+	}
+	return nil
+}
+
+func (s *Storage) Delete(ctx context.Context, filePaths ...string) error {
+	client, err := s.sftpLazy.Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, fp := range filePaths {
+		objPath := path.Join(s.cwd, fp)
+
+		stat, err := client.Stat(objPath)
+		if errors.Is(err, os.ErrNotExist) {
+			// Idempotent: a missing file is not an error.
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("get stats of object %q via SFTP: %w", objPath, err)
+		}
+		// Do not try to remove a directory. It may be non-empty.
+		if stat.IsDir() {
+			continue
+		}
+
+		err = client.Remove(objPath)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("delete object %q via SFTP: %w", objPath, err)
+		}
+	}
+	return nil
+}
+
+func (s *Storage) DeleteAll(ctx context.Context, pathPrefix string) error {
+	client, err := s.sftpLazy.Client(ctx)
+	if err != nil {
+		return err
+	}
+	// Mirror os.RemoveAll: remove everything under the prefix, including the now
+	// empty directories and the prefix directory itself. SFTP has no recursive
+	// remove, and leaving the emptied directories behind would make a deleted
+	// dump still surface in list-dumps as an empty, status-less directory.
+	if err := removeAll(client, path.Join(s.cwd, pathPrefix)); err != nil {
+		return fmt.Errorf("error deleting %q: %w", pathPrefix, err)
+	}
+	return nil
+}
+
+// removeAll recursively deletes p and everything below it: files are removed,
+// directories are emptied then removed, and p itself is removed. A missing p is
+// not an error (idempotent), matching os.RemoveAll.
+func removeAll(client SFTPClient, p string) error {
+	info, err := client.Stat(p)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get stats of %q via SFTP: %w", p, err)
+	}
+
+	if !info.IsDir() {
+		if err := client.Remove(p); errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("delete object %q via SFTP: %w", p, err)
+		}
+		return nil
+	}
+
+	entries, err := client.ReadDir(p)
+	if err != nil {
+		return fmt.Errorf("read SFTP dir %q: %w", p, err)
+	}
+	for _, e := range entries {
+		if err := removeAll(client, client.Join(p, e.Name())); err != nil {
+			return err
+		}
+	}
+	if err := client.RemoveDirectory(p); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("remove SFTP dir %q: %w", p, err)
+	}
+	return nil
+}
+
+func (s *Storage) Exists(ctx context.Context, fileName string) (bool, error) {
+	client, err := s.sftpLazy.Client(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	objPath := path.Join(s.cwd, fileName)
+	_, err = client.Stat(objPath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check file %q existence via SFTP: %w", objPath, err)
+	}
+	return true, nil
+}
+
+func (s *Storage) SubStorage(subPath string, relative bool) storages.Storager {
+	cwd := subPath
+	if relative {
+		cwd = path.Join(s.cwd, subPath)
+	}
+	return &Storage{
+		cfg:      s.cfg,
+		sftpLazy: s.sftpLazy,
+		cwd:      cwd,
+	}
+}
+
+func (s *Storage) Stat(fileName string) (*domains.ObjectStat, error) {
+	// Stat has no ctx in the Storager interface; use the background context so
+	// a lazy connect here still falls back to the global logger.
+	client, err := s.sftpLazy.Client(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	fullPath := path.Join(s.cwd, fileName)
+	fileInfo, err := client.Stat(fullPath)
+	if os.IsNotExist(err) {
+		return &domains.ObjectStat{
+			Name:  fullPath,
+			Exist: false,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error getting file stat: %w", err)
+	}
+
+	return &domains.ObjectStat{
+		Name:         fullPath,
+		LastModified: fileInfo.ModTime(),
+		Exist:        true,
+	}, nil
+}

--- a/internal/storages/ssh/ssh_test.go
+++ b/internal/storages/ssh/ssh_test.go
@@ -1,0 +1,512 @@
+// Copyright 2026 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/greenmaskio/greenmask/internal/storages"
+)
+
+// --- No-network unit tests -------------------------------------------------
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *Config
+		wantErr  bool
+		wantPort int
+	}{
+		{
+			name:    "missing host",
+			cfg:     &Config{User: "u", Password: "p", Port: 22},
+			wantErr: true,
+		},
+		{
+			name:    "missing user",
+			cfg:     &Config{Host: "h", Password: "p", Port: 22},
+			wantErr: true,
+		},
+		{
+			name:    "missing auth",
+			cfg:     &Config{Host: "h", User: "u", Port: 22},
+			wantErr: true,
+		},
+		{
+			name:     "valid with password",
+			cfg:      &Config{Host: "h", User: "u", Password: "p", Port: 22},
+			wantErr:  false,
+			wantPort: 22,
+		},
+		{
+			name:     "valid with private key path",
+			cfg:      &Config{Host: "h", User: "u", PrivateKeyPath: "/key", Port: 22},
+			wantErr:  false,
+			wantPort: 22,
+		},
+		{
+			name:     "non-positive port clamps to default",
+			cfg:      &Config{Host: "h", User: "u", Password: "p", Port: 0},
+			wantErr:  false,
+			wantPort: defaultPort,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPort, tt.cfg.Port)
+		})
+	}
+}
+
+func TestNewConfig_Defaults(t *testing.T) {
+	cfg := NewConfig()
+	assert.Equal(t, defaultPort, cfg.Port)
+}
+
+func TestBuildAuthMethods(t *testing.T) {
+	keyPath := writeTestPrivateKey(t)
+
+	t.Run("both: private key precedes password", func(t *testing.T) {
+		methods, err := buildAuthMethods(&Config{
+			User:           "u",
+			Password:       "p",
+			PrivateKeyPath: keyPath,
+		})
+		require.NoError(t, err)
+		// Two methods, with the public-key method first.
+		require.Len(t, methods, 2)
+		assert.Equal(t, "publickey", reflectMethodName(methods[0]))
+		assert.Equal(t, "password", reflectMethodName(methods[1]))
+	})
+
+	t.Run("password only", func(t *testing.T) {
+		methods, err := buildAuthMethods(&Config{User: "u", Password: "p"})
+		require.NoError(t, err)
+		require.Len(t, methods, 1)
+		assert.Equal(t, "password", reflectMethodName(methods[0]))
+	})
+
+	t.Run("key only", func(t *testing.T) {
+		methods, err := buildAuthMethods(&Config{User: "u", PrivateKeyPath: keyPath})
+		require.NoError(t, err)
+		require.Len(t, methods, 1)
+		assert.Equal(t, "publickey", reflectMethodName(methods[0]))
+	})
+
+	t.Run("unreadable key errors", func(t *testing.T) {
+		_, err := buildAuthMethods(&Config{User: "u", PrivateKeyPath: path.Join(t.TempDir(), "nope")})
+		assert.Error(t, err)
+	})
+
+	t.Run("malformed key errors", func(t *testing.T) {
+		bad := path.Join(t.TempDir(), "bad_key")
+		require.NoError(t, os.WriteFile(bad, []byte("not a key"), 0o600))
+		_, err := buildAuthMethods(&Config{User: "u", PrivateKeyPath: bad})
+		assert.Error(t, err)
+	})
+}
+
+// reflectMethodName reports the SSH auth method name ("publickey" / "password")
+// of an ssh.AuthMethod. The concrete types are unexported, so we identify them
+// by their method() string, which ssh.AuthMethod exposes via the wire name.
+func reflectMethodName(m ssh.AuthMethod) string {
+	switch fmt.Sprintf("%T", m) {
+	case "ssh.publicKeyCallback":
+		return "publickey"
+	case "ssh.passwordCallback":
+		return "password"
+	default:
+		return fmt.Sprintf("%T", m)
+	}
+}
+
+// writeTestPrivateKey generates an ed25519 OpenSSH private key, writes it to a
+// temp file and returns the path.
+func writeTestPrivateKey(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	require.NoError(t, err)
+	keyPath := path.Join(t.TempDir(), "id_ed25519")
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(block), 0o600))
+	return keyPath
+}
+
+// --- atmoz/sftp testcontainer harness --------------------------------------
+//
+// A single SFTP container is shared across all round-trip tests (started lazily
+// on first use, terminated in TestMain). Each test gets its own unique prefix
+// via newTestStorage so cases stay isolated.
+
+const (
+	sftpImage    = "atmoz/sftp:alpine"
+	sftpUser     = "testuser"
+	sftpPassword = "testpass"
+)
+
+var (
+	sftpOnce sync.Once
+	sftpCtr  testcontainers.Container
+	sftpHost string
+	sftpPort int
+	sftpErr  error
+
+	prefixCounter atomic.Int64
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sftpCtr != nil {
+		_ = sftpCtr.Terminate(context.Background())
+	}
+	os.Exit(code)
+}
+
+// sftpEndpoint lazily starts the shared atmoz/sftp container and returns its
+// host and mapped port. The command provisions user testuser/testpass with a
+// writable /upload directory.
+func sftpEndpoint(t *testing.T) (string, int) {
+	t.Helper()
+	sftpOnce.Do(func() {
+		ctx := context.Background()
+		req := testcontainers.ContainerRequest{
+			Image:        sftpImage,
+			ExposedPorts: []string{"22/tcp"},
+			Cmd:          []string{fmt.Sprintf("%s:%s:::upload", sftpUser, sftpPassword)},
+			WaitingFor:   wait.ForListeningPort("22/tcp"),
+		}
+		sftpCtr, sftpErr = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if sftpErr != nil {
+			return
+		}
+		sftpHost, sftpErr = sftpCtr.Host(ctx)
+		if sftpErr != nil {
+			return
+		}
+		mapped, err := sftpCtr.MappedPort(ctx, "22/tcp")
+		if err != nil {
+			sftpErr = err
+			return
+		}
+		sftpPort = int(mapped.Num())
+	})
+	require.NoError(t, sftpErr)
+	return sftpHost, sftpPort
+}
+
+// newTestStorage returns a Storage pointed at a unique prefix under /upload in
+// the shared SFTP container.
+func newTestStorage(t *testing.T) *Storage {
+	t.Helper()
+	host, port := sftpEndpoint(t)
+	cfg := &Config{
+		Host:     host,
+		Port:     port,
+		User:     sftpUser,
+		Password: sftpPassword,
+		Prefix:   fmt.Sprintf("/upload/test-%d", prefixCounter.Add(1)),
+	}
+	st, err := NewStorage(cfg)
+	require.NoError(t, err)
+	return st
+}
+
+func putObject(t *testing.T, st *Storage, key string, content []byte) {
+	t.Helper()
+	require.NoError(t, st.PutObject(context.Background(), key, bytes.NewReader(content)))
+}
+
+func mustGet(t *testing.T, st *Storage, key string) []byte {
+	t.Helper()
+	r, err := st.GetObject(context.Background(), key)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return data
+}
+
+func dirNames(dirs []storages.Storager) []string {
+	names := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		names = append(names, d.Dirname())
+	}
+	return names
+}
+
+func TestSSHOps(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("new storage", func(t *testing.T) {
+		st := newTestStorage(t)
+		// Lazy-connect succeeds (Exists forces the connection).
+		_, err := st.Exists(ctx, "anything")
+		require.NoError(t, err)
+	})
+
+	t.Run("put object", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "test.txt", []byte("root"))
+		putObject(t, st, "testdb/test.txt", []byte("nested"))
+		assert.Equal(t, []byte("root"), mustGet(t, st, "test.txt"))
+		assert.Equal(t, []byte("nested"), mustGet(t, st, "testdb/test.txt"))
+	})
+
+	t.Run("get object", func(t *testing.T) {
+		st := newTestStorage(t)
+		payload := []byte("hello sftp world")
+		putObject(t, st, "payload.bin", payload)
+		assert.Equal(t, payload, mustGet(t, st, "payload.bin"))
+	})
+
+	t.Run("walking", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "root.txt", []byte("r"))
+		putObject(t, st, "sub/nested.txt", []byte("n"))
+
+		files, dirs, err := st.ListDir(ctx)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"root.txt"}, files)
+		assert.ElementsMatch(t, []string{"sub"}, dirNames(dirs))
+
+		require.Len(t, dirs, 1)
+		child := dirs[0]
+		assert.Equal(t, path.Join(st.GetCwd(), "sub"), child.GetCwd())
+		childFiles, _, err := child.ListDir(ctx)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"nested.txt"}, childFiles)
+	})
+
+	t.Run("exists", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "a.txt", []byte("a"))
+		putObject(t, st, "d/b.txt", []byte("b"))
+
+		ok, err := st.Exists(ctx, "a.txt")
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		ok, err = st.Exists(ctx, "d/b.txt")
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		ok, err = st.Exists(ctx, "missing.txt")
+		require.NoError(t, err)
+		assert.False(t, ok)
+
+		require.NoError(t, st.Delete(ctx, "a.txt"))
+		ok, err = st.Exists(ctx, "a.txt")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("sub storage", func(t *testing.T) {
+		st := newTestStorage(t)
+		sub := st.SubStorage("sub", true)
+		content := []byte("sub-storage-payload")
+		require.NoError(t, sub.PutObject(ctx, "test.txt", bytes.NewReader(content)))
+
+		reader, err := sub.GetObject(ctx, "test.txt")
+		require.NoError(t, err)
+		defer func() { _ = reader.Close() }()
+		data, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		assert.Equal(t, content, data)
+
+		assert.Equal(t, content, mustGet(t, st, "sub/test.txt"))
+	})
+
+	t.Run("stat", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "s.txt", []byte("data"))
+
+		stat, err := st.Stat("s.txt")
+		require.NoError(t, err)
+		assert.True(t, stat.Exist)
+		assert.Equal(t, path.Join(st.GetCwd(), "s.txt"), stat.Name)
+		assert.False(t, stat.LastModified.IsZero())
+
+		missing, err := st.Stat("nope.txt")
+		require.NoError(t, err)
+		assert.False(t, missing.Exist)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		st := newTestStorage(t)
+		_, err := st.GetObject(ctx, "ghost.txt")
+		assert.ErrorIs(t, err, storages.ErrFileNotFound)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "a.txt", []byte("a"))
+		putObject(t, st, "b.txt", []byte("b"))
+
+		require.NoError(t, st.Delete(ctx, "a.txt"))
+		// Deleting a missing file is idempotent.
+		require.NoError(t, st.Delete(ctx, "ghost.txt"))
+
+		ok, err := st.Exists(ctx, "a.txt")
+		require.NoError(t, err)
+		assert.False(t, ok)
+		ok, err = st.Exists(ctx, "b.txt")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("delete_all", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "books/a.txt", []byte("a"))
+		putObject(t, st, "books/sci/b.txt", []byte("b"))
+		putObject(t, st, "users/u.txt", []byte("u"))
+
+		require.NoError(t, st.DeleteAll(ctx, "books"))
+
+		remaining, err := storages.Walk(ctx, st, "")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"users/u.txt"}, remaining)
+
+		// DeleteAll must remove the now-empty directory tree, not just the
+		// files — otherwise a deleted dump still surfaces in list-dumps as an
+		// empty, status-less directory.
+		_, dirs, err := st.ListDir(ctx)
+		require.NoError(t, err)
+		assert.NotContains(t, dirNames(dirs), "books", "empty dump directory must be removed")
+
+		exists, err := st.Exists(ctx, "books")
+		require.NoError(t, err)
+		assert.False(t, exists, "the prefix directory itself must be gone")
+	})
+
+	t.Run("delete_all nested subdirs", func(t *testing.T) {
+		st := newTestStorage(t)
+		// A multi-level tree under dump/, with branches and files at several
+		// depths, plus a sibling tree (keep/) that must survive untouched.
+		putObject(t, st, "dump/meta.json", []byte("m"))
+		putObject(t, st, "dump/data/a.dat", []byte("a"))
+		putObject(t, st, "dump/data/blobs/b.dat", []byte("b"))
+		putObject(t, st, "dump/data/blobs/deep/c.dat", []byte("c"))
+		putObject(t, st, "dump/schema/tables/t.sql", []byte("t"))
+		putObject(t, st, "keep/k.txt", []byte("k"))
+
+		require.NoError(t, st.DeleteAll(ctx, "dump"))
+
+		// Every file under dump/ is gone; the sibling tree is untouched.
+		remaining, err := storages.Walk(ctx, st, "")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"keep/k.txt"}, remaining)
+
+		// No part of the nested directory tree may linger — not the prefix dir
+		// nor any intermediate subdirectory.
+		_, dirs, err := st.ListDir(ctx)
+		require.NoError(t, err)
+		assert.NotContains(t, dirNames(dirs), "dump", "the prefix directory must be removed")
+
+		for _, dir := range []string{"dump", "dump/data", "dump/data/blobs", "dump/data/blobs/deep", "dump/schema", "dump/schema/tables"} {
+			exists, err := st.Exists(ctx, dir)
+			require.NoError(t, err)
+			assert.Falsef(t, exists, "nested directory %q must be removed", dir)
+		}
+	})
+
+	t.Run("remove on a directory errors", func(t *testing.T) {
+		// removeAll relies on SFTP Remove being a file-only op (RemoveDirectory
+		// handles dirs). This guards that invariant: calling Remove on a
+		// directory must fail rather than silently no-op or delete recursively.
+		// If this ever stops failing, removeAll's file/dir branching can rot.
+		st := newTestStorage(t)
+		putObject(t, st, "adir/child.txt", []byte("c"))
+
+		client, err := st.sftpLazy.Client(ctx)
+		require.NoError(t, err)
+		dirPath := path.Join(st.GetCwd(), "adir")
+
+		require.Error(t, client.Remove(dirPath), "SFTP Remove must reject a directory")
+
+		// RemoveDirectory is also strict: it refuses a non-empty directory.
+		require.Error(t, client.RemoveDirectory(dirPath), "RemoveDirectory must reject a non-empty directory")
+
+		// The directory and its contents survive the failed removals.
+		exists, err := st.Exists(ctx, "adir/child.txt")
+		require.NoError(t, err)
+		assert.True(t, exists, "failed directory removal must leave contents intact")
+	})
+}
+
+func TestStorage_Close(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("close releases the connection and blocks further use", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "a.txt", []byte("a")) // forces the connection
+
+		require.NoError(t, st.Close())
+
+		// After Close, operations fail instead of using a dead connection.
+		_, err := st.Exists(ctx, "a.txt")
+		require.ErrorIs(t, err, errStorageClosed)
+	})
+
+	t.Run("close is idempotent", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "a.txt", []byte("a"))
+		require.NoError(t, st.Close())
+		require.NoError(t, st.Close())
+	})
+
+	t.Run("close before connecting is a no-op", func(t *testing.T) {
+		st := newTestStorage(t) // never triggers a connection
+		require.NoError(t, st.Close())
+	})
+
+	t.Run("closing through a sub storage releases the shared connection", func(t *testing.T) {
+		st := newTestStorage(t)
+		putObject(t, st, "a.txt", []byte("a"))
+
+		sub := st.SubStorage("sub", true).(*Storage)
+		require.NoError(t, sub.Close())
+
+		// The parent shares the same connection, so it is closed too.
+		_, err := st.Exists(ctx, "a.txt")
+		require.ErrorIs(t, err, errStorageClosed)
+	})
+}

--- a/internal/storages/storager.go
+++ b/internal/storages/storager.go
@@ -43,4 +43,9 @@ type Storager interface {
 	SubStorage(subPath string, relative bool) Storager
 	// Stat - get the metadata info about object from the storage
 	Stat(fileName string) (*domains.ObjectStat, error)
+	// Close - release any resources held by the storage (e.g. a persistent
+	// connection). It must be called once by the lifecycle owner when the
+	// storage and all of its sub-storages are no longer needed. Backends that
+	// hold no resources implement it as a no-op.
+	Close() error
 }

--- a/internal/storages/validate/storage.go
+++ b/internal/storages/validate/storage.go
@@ -153,3 +153,8 @@ func (s *Storage) Stat(fileName string) (*domains.ObjectStat, error) {
 		LastModified: obj.lastModified,
 	}, nil
 }
+
+// Close is a no-op: this in-memory storage holds no external resources.
+func (s *Storage) Close() error {
+	return nil
+}

--- a/internal/utils/logger/logger.go
+++ b/internal/utils/logger/logger.go
@@ -29,7 +29,11 @@ const (
 	LogFormatTextValue = "text"
 )
 
-func SetLogLevel(logLevelStr string, logFormat string) error {
+var errUnknownLogFormat = fmt.Errorf("unknown log format")
+
+// GetLogger builds a zerolog.Logger for the given level and format without
+// mutating any global state.
+func GetLogger(logLevelStr string, logFormat string) (zerolog.Logger, error) {
 
 	var logLevel zerolog.Level
 	switch logLevelStr {
@@ -40,8 +44,7 @@ func SetLogLevel(logLevelStr string, logFormat string) error {
 	case zerolog.LevelWarnValue:
 		logLevel = zerolog.WarnLevel
 	default:
-		return fmt.Errorf("unknown log level %s", logLevelStr)
-
+		return zerolog.Logger{}, fmt.Errorf("log level %s: %w", logLevelStr, errUnknownLogFormat)
 	}
 
 	var formatWriter io.Writer
@@ -53,18 +56,31 @@ func SetLogLevel(logLevelStr string, logFormat string) error {
 	}
 
 	if logLevelStr == zerolog.LevelDebugValue {
-		log.Logger = zerolog.New(formatWriter).
+		return zerolog.New(formatWriter).
 			Level(logLevel).
 			With().
 			Timestamp().
 			Caller().
-			Int("pid", os.Getpid()).Logger()
-	} else {
-		log.Logger = zerolog.New(formatWriter).
-			Level(logLevel).
-			With().
-			Timestamp().
-			Logger()
+			Int("pid", os.Getpid()).Logger(), nil
 	}
+	return zerolog.New(formatWriter).
+		Level(logLevel).
+		With().
+		Timestamp().
+		Logger(), nil
+}
+
+// SetDefaultContextLogger builds a logger and installs it as both the global
+// log.Logger and zerolog.DefaultContextLogger. Installing it as the default
+// context logger makes log.Ctx(ctx) fall back to the configured logger when no
+// logger is attached to the context (greenmask does not attach one), so the
+// context-based logging idiom works everywhere instead of silently no-oping.
+func SetDefaultContextLogger(logLevelStr string, logFormat string) error {
+	l, err := GetLogger(logLevelStr, logFormat)
+	if err != nil {
+		return fmt.Errorf("get logger: %w", err)
+	}
+	zerolog.DefaultContextLogger = &l
+	log.Logger = l
 	return nil
 }

--- a/internal/utils/testutils/storage.go
+++ b/internal/utils/testutils/storage.go
@@ -66,3 +66,7 @@ func (s *StorageMock) Stat(fileName string) (*domains.ObjectStat, error) {
 	args := s.Called(fileName)
 	return args.Get(0).(*domains.ObjectStat), args.Error(1)
 }
+
+func (s *StorageMock) Close() error {
+	return nil
+}

--- a/pkg/toolkit/cmd.go
+++ b/pkg/toolkit/cmd.go
@@ -96,7 +96,7 @@ func (c *Cmd) setupDefaultCmd() {
 
 func (c *Cmd) run(cmd *cobra.Command, args []string) {
 
-	if err := logger.SetLogLevel(c.logLevel, c.logFormat); err != nil {
+	if err := logger.SetDefaultContextLogger(c.logLevel, c.logFormat); err != nil {
 		log.Err(err).Msg("")
 	}
 

--- a/playground/config-ssh.yml
+++ b/playground/config-ssh.yml
@@ -6,15 +6,13 @@ common:
   tmp_dir: "/tmp"
 
 storage:
-  type: "azure"
-  azure:
-    # Path-style endpoint of the Azurite emulator (account name included).
-    endpoint: "http://playground-storage:10000/devstoreaccount1"
-#    endpoint: "http://localhost:10000/devstoreaccount1"
-    storage_account: "devstoreaccount1"
-    # Well-known Azurite account key.
-    access_key: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-    container: "greenmask"
+  type: ssh
+  ssh:
+    host: playground-storage
+    port: 22
+    user: greenmask
+    password: greenmask
+    prefix: /dumps
 
 validate:
 #  resolved_warnings:
@@ -22,7 +20,6 @@ validate:
 
 dump:
   pg_dump_options: # pg_dump option that will be provided
-#    dbname: "host=localhost port=54316 user=postgres password=example dbname=original"
     dbname: "host=playground-db user=postgres password=example dbname=original"
     jobs: 10
 
@@ -38,5 +35,4 @@ dump:
 restore:
   pg_restore_options: # pg_restore option (you can use the same options as pg_restore has)
     jobs: 10
-#    dbname: "host=localhost port=5431 user=postgres password=example dbname=transformed"
     dbname: "host=playground-db port=5432 user=postgres password=example dbname=transformed"

--- a/tests/integration/greenmask/args.go
+++ b/tests/integration/greenmask/args.go
@@ -75,7 +75,7 @@ func init() {
 }
 
 func init() {
-	if err := logger.SetLogLevel(zerolog.LevelDebugValue, logger.LogFormatTextValue); err != nil {
+	if err := logger.SetDefaultContextLogger(zerolog.LevelDebugValue, logger.LogFormatTextValue); err != nil {
 		panic(err)
 	}
 }

--- a/tests/integration/storages/args.go
+++ b/tests/integration/storages/args.go
@@ -71,7 +71,7 @@ func init() {
 }
 
 func init() {
-	if err := logger.SetLogLevel(zerolog.LevelDebugValue, logger.LogFormatTextValue); err != nil {
+	if err := logger.SetDefaultContextLogger(zerolog.LevelDebugValue, logger.LogFormatTextValue); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Add SSH/SFTP storage backend

### Summary
Adds a new `ssh` storage backend so dumps can be stored on a remote host over SFTP, alongside the existing `directory`, `s3` and `azure` backends. This MR also includes the supporting refactors the new backend needed (resource cleanup via `Close()`, context-aware logging) and a couple of fixes uncovered along the way.

### Changes

**SSH storage backend** (`internal/storages/ssh/`)
- New SFTP-based `Storager` implementation (`ssh.go`, `sftp_lazy.go`,  `config.go`, `ssh_test.go`).
- Config: `host` (required), `port` (default 22), `user` (required), `password` **or** `private_key_path` for auth, and `prefix` as the remote root path. Validated in `Config.Validate()`.
- Wired into `domains.StorageConfig` and `builder.GetStorage`  (`type: ssh`).

**Storage lifecycle — `Close()`**
- Added `Close() error` to the `Storager` interface to release backend resources (the persistent SSH connection); a no-op for stateless backends.
- Implemented for directory, s3, azure, ssh, validate wrapper and testutils.
- Every command (`dump`, `restore`, `delete`, `list_dumps`, `show_dump`, `validate`) now closes the storage when done.

**Logger refactor** (`internal/utils/logger`)
- Split `SetLogLevel` into `GetLogger` (pure builder, no global state) and `SetDefaultContextLogger`.
- `SetDefaultContextLogger` installs `zerolog.DefaultContextLogger` so the `log.Ctx(ctx)` idiom (used by the storage builder) falls back to the configured logger instead of silently no-oping.

**delete fixes** (`cmd/.../delete/delete_dump.go`)
- `deleteDump` now reuses the `ctx`/storage built in `run()` instead of calling `builder.GetStorage` again — previously storage was created twice (duplicate `creating storage` log and a leaked connection).
- Added an `INF deleting dump` log with the `DumpId` before deletion.

**Docs / playground / misc**
- `docs/configuration.md`, `docs/playground.md`: document the ssh backend.
- `playground/config-ssh.yml`, `docker-compose-ssh.yml`, `playground/ssh`:  local SFTP playground.
- `go.mod` / `go.sum`: add SFTP/SSH dependencies.
- `Makefile`: playground targets.
