### PR TITLE
feat: support the config file path via an env var

### DIFF
--- a/cmd/greenmask/cmd/root.go
+++ b/cmd/greenmask/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"runtime/debug"
 	"strings"
 
@@ -124,6 +125,10 @@ func init() {
 }
 
 func initConfig() {
+	if cfgFile == "" {
+		cfgFile = os.Getenv("GREENMASK_CONFIG")
+	}
+
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 		if err := viper.ReadInConfig(); err != nil {

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -2,8 +2,10 @@
 #
 # Layered on top of docker-compose.yml, it overrides the `playground-storage`
 # service so the Minio (S3) backend is swapped for an Azurite Blob Storage
-# emulator. Everything else (playground-db, playground-dbs-filler, greenmask,
-# greenmask-from-source) is inherited from the base file unchanged.
+# emulator, adds a one-shot `playground-storage-init` job, and extends
+# greenmask/greenmask-from-source to also wait on that job. Everything else
+# (playground-db, playground-dbs-filler) is inherited from the base file
+# unchanged.
 #
 # Run it (note both -f flags, base first):
 #

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -31,6 +31,7 @@ optional, with the default format set to `text`.
 * `--log-level` — sets the desired level for log output, which can be one of `debug`, `info`, or `warn`. This parameter
 is optional, with the default log level being `info`.
 * `--config` — requires the specification of a configuration file in YAML format. This configuration file is mandatory
-for Greenmask to operate correctly.
+for Greenmask to operate correctly. The path may also be provided via the `GREENMASK_CONFIG` environment variable;
+when both are set, the `--config` flag takes precedence.
 * `--help` — displays comprehensive help information for Greenmask, providing guidance on its usage and available
 commands.


### PR DESCRIPTION
Changes:
* Now root cmd gets `GREENMASK_CONFIG` value if the `--config` flag is not provided explicitly


Example:

```shell
GREENMASK_CONFIG=config-ssh.yml greenmask dump
```

Closes #455