### PR TITLE
feat: Added validate --strict parameter

### DIFF
--- a/cmd/greenmask/cmd/validate/validate.go
+++ b/cmd/greenmask/cmd/validate/validate.go
@@ -181,4 +181,13 @@ func init() {
 		log.Fatal().Err(err).Msg("fatal")
 	}
 
+	strictFlagName := "strict"
+	Cmd.Flags().Bool(
+		strictFlagName, false, "Exit with non-zero code if there are any validation warnings (warnings-as-errors)",
+	)
+	flag = Cmd.Flags().Lookup(strictFlagName)
+	if err := viper.BindPFlag("validate.strict", flag); err != nil {
+		log.Fatal().Err(err).Msg("fatal")
+	}
+
 }

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -14,6 +14,7 @@ Flags:
       --format string         Format of output. possible values [text|json] (default "text")
       --rows-limit uint       Check tables dump only for specific tables (default 10)
       --schema                Make a schema diff between previous dump and the current state
+      --strict                Exit with non-zero code if there are any validation warnings (warnings-as-errors)
       --table strings         Check tables dump only for specific tables
       --table-format string   Format of table output (only for --format=text). Possible values [vertical|horizontal] (default "vertical")
       --transformed-only      Print only transformed column and primary key
@@ -23,11 +24,18 @@ Flags:
 Validate command can exit with non-zero code when:
 
 * Any error occurred
-* Validate was called with `--warnings` flag and there are warnings
+* There is a validation warning with severity `"error"`
+* Validate was called with `--strict` flag and there are any unresolved warnings (warnings-as-errors)
 * Validate was called with `--schema` flag and there are schema differences
 
+The `--warnings` flag only controls **printing** of warnings — it does **not** affect the exit code. Use
+`--strict` when you want any unresolved warning to fail the command (the equivalent of `gcc -Werror`). In strict
+mode warnings are always printed regardless of `--warnings`, and warnings whose hash is listed in
+`resolved_warnings` are not treated as failures.
+
 All of those cases may be used for CI/CD pipelines to stop the process when something went wrong. This is especially
-useful when `--schema` flag is used - this allows to avoid data leakage when schema changed.
+useful when `--schema` or `--strict` flag is used - this allows to avoid data leakage when schema changed or to
+enforce a clean validation result.
 
 You can use the `--table` flag multiple times to specify the tables you want to check. Tables can be written with
 or without schema names (e.g., `public.table_name` or `table_name`). If you specify multiple tables from different

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -28,13 +28,12 @@ Validate command can exit with non-zero code when:
 * Validate was called with `--strict` flag and there are any unresolved warnings (warnings-as-errors)
 * Validate was called with `--schema` flag and there are schema differences
 
-The `--warnings` flag only controls **printing** of warnings — it does **not** affect the exit code. Use
-`--strict` when you want any unresolved warning to fail the command. In strict mode warnings are always printed 
-regardless of `--warnings`, and warnings whose hash is listed in `resolved_warnings` are not treated as failures.
+The `--warnings` flag only controls **printing** of warnings — it does **not** affect the exit code. In strict mode
+warnings are always printed regardless of `--warnings`, and warnings whose hash is listed in `resolved_warnings` are
+not treated as failures.
 
-All of those cases may be used for CI/CD pipelines to stop the process when something went wrong. This is especially
-useful when `--schema` or `--strict` flag is used - this allows to avoid data leakage when schema changed or to
-enforce a clean validation result.
+These non-zero exit codes let CI/CD pipelines stop on problems — particularly useful with `--schema` or `--strict`,
+which guard against data leakage on schema changes and enforce a clean validation result.
 
 You can use the `--table` flag multiple times to specify the tables you want to check. Tables can be written with
 or without schema names (e.g., `public.table_name` or `table_name`). If you specify multiple tables from different

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -29,9 +29,8 @@ Validate command can exit with non-zero code when:
 * Validate was called with `--schema` flag and there are schema differences
 
 The `--warnings` flag only controls **printing** of warnings — it does **not** affect the exit code. Use
-`--strict` when you want any unresolved warning to fail the command (the equivalent of `gcc -Werror`). In strict
-mode warnings are always printed regardless of `--warnings`, and warnings whose hash is listed in
-`resolved_warnings` are not treated as failures.
+`--strict` when you want any unresolved warning to fail the command. In strict mode warnings are always printed 
+regardless of `--warnings`, and warnings whose hash is listed in `resolved_warnings` are not treated as failures.
 
 All of those cases may be used for CI/CD pipelines to stop the process when something went wrong. This is especially
 useful when `--schema` or `--strict` flag is used - this allows to avoid data leakage when schema changed or to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,6 +368,7 @@ validate:
   schema: true # (8)
   transformed_only: true # (9)
   warnings: true # (10)
+  strict: true # (11)
 ```
 { .annotate }
 
@@ -380,7 +381,8 @@ validate:
 7. The output format (json or text)
 8. Specifies whether to validate the current schema with the previous and print the differences if any.
 9. If set to `true`, transformation output will be only with the transformed columns and primary keys
-10. If set to then all the warnings be printed
+10. If set to `true` then all the warnings will be printed. This only controls printing and does not affect the exit code.
+11. If set to `true`, the validate command exits with a non-zero code when there are any unresolved warnings (warnings-as-errors). Warnings listed in `resolved_warnings` are not treated as failures. Useful for CI/CD pipelines.
 
 ## `restore` section
 

--- a/internal/db/postgres/cmd/validate.go
+++ b/internal/db/postgres/cmd/validate.go
@@ -133,13 +133,17 @@ func (v *Validate) Run(ctx context.Context) (int, error) {
 	}
 
 	err = toolkit.PrintValidationWarnings(
-		v.context.Warnings, v.config.Validate.ResolvedWarnings, v.config.Validate.Warnings,
+		v.context.Warnings, v.config.Validate.ResolvedWarnings,
+		v.config.Validate.Warnings || v.config.Validate.Strict,
 	)
 	if err != nil {
 		return nonZeroExitCode, err
 	}
 	if v.context.IsFatal() {
 		return nonZeroExitCode, fmt.Errorf("fatal validation error")
+	}
+	if v.config.Validate.Strict && v.context.Warnings.HasUnresolved(v.config.Validate.ResolvedWarnings) {
+		v.exitCode = nonZeroExitCode
 	}
 
 	if err = v.diffWithPreviousSchema(ctx); err != nil {

--- a/internal/domains/config.go
+++ b/internal/domains/config.go
@@ -79,6 +79,7 @@ type Validate struct {
 	Format           string   `mapstructure:"format" yaml:"format" json:"format,omitempty"`
 	OnlyTransformed  bool     `mapstructure:"transformed_only" yaml:"transformed_only" json:"transformed_only,omitempty"`
 	Warnings         bool     `mapstructure:"warnings" yaml:"warnings" json:"warnings,omitempty"`
+	Strict           bool     `mapstructure:"strict" yaml:"strict" json:"strict,omitempty"`
 }
 
 type Common struct {

--- a/pkg/toolkit/validation_warning.go
+++ b/pkg/toolkit/validation_warning.go
@@ -38,6 +38,19 @@ func (re ValidationWarnings) IsFatal() bool {
 	})
 }
 
+// HasUnresolved reports whether any warning of severity "warning" or "error"
+// has not been explicitly resolved via resolvedWarnings. It is used by the
+// validate command's strict mode to treat warnings as errors.
+func (re ValidationWarnings) HasUnresolved(resolvedWarnings []string) bool {
+	return slices.ContainsFunc(re, func(warning *ValidationWarning) bool {
+		if warning.Severity != WarningValidationSeverity && warning.Severity != ErrorValidationSeverity {
+			return false
+		}
+		warning.MakeHash()
+		return slices.Index(resolvedWarnings, warning.Hash) == -1
+	})
+}
+
 type ValidationWarning struct {
 	Msg      string         `json:"msg,omitempty"`
 	Severity string         `json:"severity,omitempty"`

--- a/pkg/toolkit/validation_warning_test.go
+++ b/pkg/toolkit/validation_warning_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Greenmask
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolkit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidationWarnings_HasUnresolved(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		var warns ValidationWarnings
+		assert.False(t, warns.HasUnresolved(nil))
+	})
+
+	t.Run("unresolved warning severity", func(t *testing.T) {
+		warns := ValidationWarnings{
+			NewValidationWarning().SetSeverity(WarningValidationSeverity).SetMsg("w"),
+		}
+		assert.True(t, warns.HasUnresolved(nil))
+	})
+
+	t.Run("unresolved error severity", func(t *testing.T) {
+		warns := ValidationWarnings{
+			NewValidationWarning().SetSeverity(ErrorValidationSeverity).SetMsg("e"),
+		}
+		assert.True(t, warns.HasUnresolved(nil))
+	})
+
+	t.Run("info and debug are ignored", func(t *testing.T) {
+		warns := ValidationWarnings{
+			NewValidationWarning().SetSeverity(InfoValidationSeverity).SetMsg("i"),
+			NewValidationWarning().SetSeverity(DebugValidationSeverity).SetMsg("d"),
+		}
+		assert.False(t, warns.HasUnresolved(nil))
+	})
+
+	t.Run("resolved warning is excluded", func(t *testing.T) {
+		w := NewValidationWarning().SetSeverity(WarningValidationSeverity).SetMsg("w")
+		w.MakeHash()
+		warns := ValidationWarnings{w}
+		assert.False(t, warns.HasUnresolved([]string{w.Hash}))
+	})
+
+	t.Run("one resolved, one unresolved", func(t *testing.T) {
+		resolved := NewValidationWarning().SetSeverity(WarningValidationSeverity).SetMsg("resolved")
+		resolved.MakeHash()
+		unresolved := NewValidationWarning().SetSeverity(WarningValidationSeverity).SetMsg("unresolved")
+		warns := ValidationWarnings{resolved, unresolved}
+		assert.True(t, warns.HasUnresolved([]string{resolved.Hash}))
+	})
+}


### PR DESCRIPTION
Exit with -1 if there are unresolved warnings

Example

```shell
greenmask@da83cc38d0a8:/var/lib/playground$ greenmask --config config-ssh.yml validate --strict && echo 'ok' || echo 'fatal'
2026-06-26T19:27:04Z DBG ../greenmask/internal/db/postgres/cmd/dump.go:169 > performing snapshot export pid=105
2026-06-26T19:27:04Z WRN ../greenmask/pkg/toolkit/validation_warning.go:124 > ValidationWarning={"hash":"aa808fb574a1359c6606e464833feceb","meta":{"ColumnName":"birthdate","ConstraintDef":"CHECK (birthdate >= '1930-01-01'::date AND birthdate <= (now() - '18 years'::interval))","ConstraintName":"humanresources","ConstraintSchema":"humanresources","ConstraintType":"Check","ParameterName":"column","SchemaName":"humanresources","TableName":"employee","TransformerName":"NoiseDate"},"msg":"possible constraint violation: column has Check constraint","severity":"warning"} pid=105
fatal
```

Closed #454 